### PR TITLE
fix: temp override design-system tokens to fix compaitibility with old design system

### DIFF
--- a/.storybook/StoryPage.css
+++ b/.storybook/StoryPage.css
@@ -1,0 +1,12 @@
+/* These values are currently set in our old design system, which is being used in app-frontend.
+We need to ensure that our new components look fine with these values set.
+In the future, we may want to get rid of these rules.
+*/
+
+html {
+  font-size: 62.5%;
+}
+
+body {
+  font-size: 1rem;
+}

--- a/.storybook/StoryPage.tsx
+++ b/.storybook/StoryPage.tsx
@@ -7,6 +7,7 @@ import {
   Heading,
   PRIMARY_STORY,
 } from '@storybook/addon-docs';
+import './StoryPage.css';
 
 interface StoryPageProps {
   description: string; // supports markdown

--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ Lint checks and auto-fixes will be run automatically on commit.
 
 New components can be added by executing `yarn add-component <ComponentName>`. The name of the component should be written using PascalCase. This will generate all important files for you in the correct location, and also update the index file for exporting the component. The generated code includes some `TODO` statements that you should fix.
 
+### Styling
+
+Styling should primarily be done in css files using css variables. The css files should end with `.module.css`, so unique classnames will be generated. This ensures we will not run into naming collision issues with classnames.
+
+We are using Figma as our design tool, and we are extracting tokens directly from Figma that can be used in code. These tokens are defined in the [figma-design-tokens repository](https://github.com/Altinn/figma-design-tokens). New components should ideally be using design tokens from there to define their layout. Before work is started on the component, you should discuss with the UX group first, because they need to define the tokens for the components.
+
+#### Classname naming conventions
+
+Using [BEM naming convention](http://getbem.com/naming/) gives a pretty clear view of what parts are the "root" and what parts are the "children", and is preferred. This also helps you think about when a component grows too big, and should be split into smaller isolated parts.
+
 ## Code style
 
 We use [eslint](https://eslint.org/) and [prettier](https://prettier.io/), and automatically set up git hooks to enforce

--- a/src/components/Panel/Panel.module.css
+++ b/src/components/Panel/Panel.module.css
@@ -1,15 +1,58 @@
-:root {
-  --panel-top-padding: var(--component-panel-space-padding-top-md);
-  --panel-right-padding: var(--component-panel-space-padding-right-md);
-  --panel-bottom-padding: var(--component-panel-space-padding-bottom-md);
-  --panel-left-padding: var(--component-panel-space-padding-left-md);
-  --panel-content-gap: var(--component-panel-space-padding-gap-horizontal-md);
-  --panel-pointer-width: calc(var(--component-panel-size-icon-md) / 2);
-  --panel-pointer-height: calc(var(--panel-pointer-width) / 2);
-
-  --panel-body-font-size: var(--component-panel-font-size-body-lg);
-  --panel-header-font-size: var(--component-panel-font-size-header-lg);
+/* override design system tokens, because new design system is based on 100% / 16px font size.
+Old design system is based on 62.5% / 10px font size.
+These are temporary until we figure out a permanent solution for the new design system moving forward
+*/
+.panel {
+  --component-panel-space-padding-top-xs: calc(1.5rem * 1.6);
+  --component-panel-space-padding-right-xs: calc(1.5rem * 1.6);
+  --component-panel-space-padding-bottom-xs: calc(1.5rem * 1.6);
+  --component-panel-space-padding-left-xs: calc(1.5rem * 1.6);
+  --component-panel-space-padding-gap-horizontal-xs: calc(0.75rem * 1.6);
+  --component-panel-size-icon-xs: calc(2.25rem * 1.6);
+  --component-panel-font-size-body-xs: calc(1rem * 1.6);
+  --component-panel-font-size-header-xs: calc(1.125rem * 1.6);
+  --component-panel-space-padding-top-md: calc(2.25rem * 1.6);
+  --component-panel-space-padding-right-md: calc(6rem * 1.6);
+  --component-panel-space-padding-bottom-md: calc(2.25rem * 1.6);
+  --component-panel-space-padding-left-md: calc(6rem * 1.6);
+  --component-panel-space-padding-gap-horizontal-md: calc(0.75rem * 1.6);
+  --component-panel-size-icon-md: calc(3.75rem * 1.6);
+  --component-panel-font-size-body-lg: calc(1.125rem * 1.6);
+  --component-panel-font-size-header-lg: calc(1.375rem * 1.6);
 }
+
+/* TODO: cannot use css variables in media queries.. Consider using https://github.com/postcss/postcss-custom-media */
+/* breakpoints-xs */
+@media only screen and (min-width: 0) {
+  .panel {
+    --panel-top-padding: var(--component-panel-space-padding-top-xs);
+    --panel-right-padding: var(--component-panel-space-padding-right-xs);
+    --panel-bottom-padding: var(--component-panel-space-padding-bottom-xs);
+    --panel-left-padding: var(--component-panel-space-padding-left-xs);
+    --panel-content-gap: var(--component-panel-space-padding-gap-horizontal-xs);
+    --panel-pointer-width: calc(var(--component-panel-size-icon-xs) / 2);
+    --panel-pointer-height: calc(var(--panel-pointer-width) / 2);
+    --panel-body-font-size: var(--component-panel-font-size-body-xs);
+    --panel-header-font-size: var(--component-panel-font-size-header-xs);
+  }
+}
+
+/* breakpoints-sm */
+@media only screen and (min-width: 540px) {
+  .panel {
+    --panel-top-padding: var(--component-panel-space-padding-top-md);
+    --panel-right-padding: var(--component-panel-space-padding-right-md);
+    --panel-bottom-padding: var(--component-panel-space-padding-bottom-md);
+    --panel-left-padding: var(--component-panel-space-padding-left-md);
+    --panel-content-gap: var(--component-panel-space-padding-gap-horizontal-md);
+    --panel-pointer-width: calc(var(--component-panel-size-icon-md) / 2);
+    --panel-pointer-height: calc(var(--panel-pointer-width) / 2);
+    --panel-body-font-size: var(--component-panel-font-size-body-lg);
+    --panel-header-font-size: var(--component-panel-font-size-header-lg);
+  }
+}
+
+/* TODO: Implement missing breakpoints */
 
 .panel {
   position: relative;
@@ -25,7 +68,7 @@
   position: absolute;
   width: var(--panel-pointer-width);
   height: var(--panel-pointer-height);
-  top: 0;
+  top: 1px; /* slight offset to avoid mini gap between component and pointer */
   left: calc(var(--panel-left-padding) + (var(--panel-pointer-width) / 2));
   clip-path: polygon(50% 0, 100% 100%, 0 100%);
 }
@@ -73,18 +116,4 @@
 
 .panel__body {
   font-size: var(--panel-body-font-size);
-}
-
-/* TODO: cannot use css variables in media queries.. Consider using https://github.com/postcss/postcss-custom-media */
-/* @media only screen and (max-width: var(--breakpoints-sm)) { */
-@media only screen and (max-width: 540px) {
-  :root {
-    --panel-top-padding: var(--component-panel-space-padding-top-xs);
-    --panel-right-padding: var(--component-panel-space-padding-right-xs);
-    --panel-bottom-padding: var(--component-panel-space-padding-bottom-xs);
-    --panel-left-padding: var(--component-panel-space-padding-left-xs);
-    --panel-content-gap: var(--component-panel-space-padding-gap-horizontal-xs);
-    --panel-body-font-size: var(--component-panel-font-size-body-xs);
-    --panel-header-font-size: var(--component-panel-font-size-header-xs);
-  }
 }

--- a/src/components/Panel/Panel.test.tsx
+++ b/src/components/Panel/Panel.test.tsx
@@ -99,7 +99,7 @@ describe('Panel', () => {
       render({ renderIcon });
 
       expect(renderIcon).toHaveBeenCalledWith({
-        size: '3.75rem',
+        size: 'calc(3.75rem * 1.6)',
         variant: PanelVariant.Info,
       });
     });
@@ -111,7 +111,7 @@ describe('Panel', () => {
       render({ renderIcon });
 
       expect(renderIcon).toHaveBeenCalledWith({
-        size: '2.25rem',
+        size: 'calc(2.25rem * 1.6)',
         variant: PanelVariant.Info,
       });
     });

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -2,13 +2,12 @@ import React from 'react';
 import cn from 'classnames';
 import { useMediaQuery } from '@react-hookz/web';
 import * as tokens from '@altinn/figma-design-tokens';
+// TODO: Should not import tokens directly in the components
+import '@altinn/figma-design-tokens/dist/tokens.css';
 
 import { ReactComponent as InfoIcon } from './info.svg';
 import { ReactComponent as SuccessIcon } from './success.svg';
 import classes from './Panel.module.css';
-
-// TODO: Should not import tokens directly in the components
-import '@altinn/figma-design-tokens/dist/tokens.css';
 
 export enum PanelVariant {
   Info = 'info',
@@ -57,9 +56,16 @@ export const Panel = ({
   showIcon = true,
 }: PanelProps) => {
   const isMobile = useMediaQuery(`(max-width: ${tokens.BreakpointsSm})`);
-  const iconSize = isMobile
+  const size = isMobile
     ? tokens.ComponentPanelSizeIconXs
     : tokens.ComponentPanelSizeIconMd;
+
+  // TODO: remove this workaround
+  // We need this temporary font size factor to make sure the icon is rendered correctly
+  // Because of font-size: 62.5% set on html/body in the old design system
+  const fontSizeFactor = 1.6;
+
+  const iconSize = `calc(${size} * ${fontSizeFactor})`;
 
   return (
     <div


### PR DESCRIPTION
The old design system sets font-size 62.5% (10px) on HTML element, and the new design system is designed with 100% (16px) as the root font size in mind.

We are using REM's for sizes in the new design system, and this means we need to multiply any size token with 1.6 for the values to mean the same in the new and old design system.

In the long term, we may want to get rid of the 62.5% rule on the HTML element, or we may want to switch the new design system over to also use 62.5% (10px) as the base value instead - we have not decided yet.

We anyway need this temporary fix to be able to use this component in app-frontend code. 

A permanent solution will be discussed/solved in https://github.com/Altinn/altinn-design-system/issues/15