### PR TITLE
feat: expose forceMobileLayout prop for Panel component…

### DIFF
--- a/src/components/Panel/Panel.module.css
+++ b/src/components/Panel/Panel.module.css
@@ -1,4 +1,3 @@
-/* TODO: cannot use css variables in media queries.. Consider using https://github.com/postcss/postcss-custom-media */
 /* breakpoints-xs */
 @media only screen and (min-width: 0) {
   .panel {
@@ -14,7 +13,7 @@
 
 /* breakpoints-sm */
 @media only screen and (min-width: 540px) {
-  .panel {
+  .panel:not(.panel--mobile-layout) {
     --panel-y-padding: var(--component-panel-space-padding-y-md);
     --panel-x-padding: var(--component-panel-space-padding-x-md);
     --panel-content-gap: var(--component-panel-space-padding-gap-horizontal-md);
@@ -24,8 +23,6 @@
     --panel-header-font-size: var(--component-panel-font-size-header-lg);
   }
 }
-
-/* TODO: Implement missing breakpoints */
 
 .panel {
   position: relative;
@@ -81,7 +78,6 @@
 .panel__header {
   margin: 0;
   font-size: var(--panel-header-font-size);
-  /* // TODO: font-weight */
 }
 
 .panel__body {

--- a/src/components/Panel/Panel.test.tsx
+++ b/src/components/Panel/Panel.test.tsx
@@ -116,6 +116,16 @@ describe('Panel', () => {
         variant: PanelVariant.Info,
       });
     });
+
+    it('should pass smaller size and variant to renderIcon callback when viewport is big and forceMobileLayout is true', () => {
+      const renderIcon = jest.fn();
+      render({ renderIcon, forceMobileLayout: true });
+
+      expect(renderIcon).toHaveBeenCalledWith({
+        size: tokens.ComponentPanelSizeIconXs,
+        variant: PanelVariant.Info,
+      });
+    });
   });
 });
 

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -18,7 +18,10 @@ interface RenderIconProps {
   variant: PanelVariant;
 }
 
-export interface PanelProps {
+interface UseMobileLayoutProps {
+  forceMobileLayout?: boolean;
+}
+export interface PanelProps extends UseMobileLayoutProps {
   title: React.ReactNode;
   children: React.ReactNode;
   renderIcon?: ({ size, variant }: RenderIconProps) => React.ReactNode;
@@ -47,6 +50,18 @@ const defaultRenderIcon = ({ size, variant }: RenderIconProps) => {
   }
 };
 
+const useMobileLayout = ({ forceMobileLayout }: UseMobileLayoutProps) => {
+  const matchesMobileQuery = useMediaQuery(
+    `(max-width: ${tokens.BreakpointsSm})`,
+  );
+
+  if (forceMobileLayout) {
+    return true;
+  }
+
+  return matchesMobileQuery;
+};
+
 export const Panel = ({
   renderIcon = defaultRenderIcon,
   title,
@@ -54,9 +69,11 @@ export const Panel = ({
   variant = PanelVariant.Info,
   showPointer = false,
   showIcon = true,
+  forceMobileLayout = false,
 }: PanelProps) => {
-  const isMobile = useMediaQuery(`(max-width: ${tokens.BreakpointsSm})`);
-  const iconSize = isMobile
+  const isMobileLayout = useMobileLayout({ forceMobileLayout });
+
+  const iconSize = isMobileLayout
     ? tokens.ComponentPanelSizeIconXs
     : tokens.ComponentPanelSizeIconMd;
 
@@ -64,6 +81,7 @@ export const Panel = ({
     <div
       className={cn(classes.panel, {
         [classes['panel--has-pointer']]: showPointer,
+        [classes['panel--mobile-layout']]: isMobileLayout,
       })}
     >
       {showPointer && (


### PR DESCRIPTION
… to force it to be shown in mobile layout regardless of viewport size

<!--- Provide a general summary of your changes in the Title above -->

## Description
Allows us to fix issues in Altinn Studio where we sometimes must render the Panel within a very small container. There will be some separate work in Altinn Studio to utilise this new feature for those cases.


## Related Issue(s)
- fixes #36 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
