### PR TITLE
fix: add all:initial to reset button styles to browser defaults, to a…

### DIFF
--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -1,4 +1,5 @@
 .button {
+  all: initial; /* reset all styles to default, to avoid style overrides/surprises caused by other css (from Design system v1 f.ex) */
   font-family: inherit;
   border: 0;
   font-size: var(--font-size-300);
@@ -11,7 +12,6 @@
     var(--component-button-space-padding-bottom);
   letter-spacing: var(--typography-default-letter-spacing);
   cursor: pointer;
-  line-height: normal;
 }
 
 .button:focus-visible {


### PR DESCRIPTION
## Description
Reset all button styles to browser default

We've had issues when using the button component in app-frontend, because we are still using design system v1, which is also dragging in bootstrap. These styles are adding specific styles to `button` element, which cause unexpected results. F.eks button height would be much taller because of explicit `line-height` is set on `button`.
