### PR TITLE
Minor TextField fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,8 +111,8 @@
     "yargs": "^17.5.1"
   },
   "peerDependencies": {
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,cjs,mjs}": "yarn lint --cache --fix",

--- a/src/components/TextField/TextField.test.tsx
+++ b/src/components/TextField/TextField.test.tsx
@@ -174,6 +174,29 @@ describe('TextField', () => {
       expect(handleChange).toHaveBeenCalledTimes(4);
       expect(testValue).toBe('1234');
     });
+
+    it('should not trigger onChange when component is rerendered', async () => {
+      const handleChange = jest.fn();
+      const { rerender } = render({
+        onChange: handleChange,
+        value: '1234',
+        formatting: { number: { prefix: '$', thousandSeparator: ' ' } },
+      });
+
+      expect(screen.getByDisplayValue('$1 234')).toBeInTheDocument();
+      expect(handleChange).not.toHaveBeenCalled();
+
+      rerender(
+        <TextField
+          onChange={handleChange}
+          value='12345'
+          formatting={{ number: { prefix: '$', thousandSeparator: ' ' } }}
+        />,
+      );
+
+      expect(screen.getByDisplayValue('$12 345')).toBeInTheDocument();
+      expect(handleChange).not.toHaveBeenCalled();
+    });
   });
 });
 
@@ -182,7 +205,7 @@ const render = (props: Partial<TextFieldProps> = {}) => {
     id: 'id',
     onChange: jest.fn(),
     ...props,
-  };
+  } as TextFieldProps;
 
-  renderRtl(<TextField {...allProps} />);
+  return renderRtl(<TextField {...allProps} />);
 };

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -54,11 +54,13 @@ export const TextField = ({
     values: NumberFormatValues,
     sourceInfo: SourceInfo,
   ) => {
-    replaceTargetValueWithUnformattedValue({
-      values,
-      sourceInfo,
-    });
-    onChange && onChange(sourceInfo.event);
+    if (sourceInfo.source === 'event' && onChange) {
+      replaceTargetValueWithUnformattedValue({
+        values,
+        sourceInfo,
+      });
+      onChange(sourceInfo.event);
+    }
   };
 
   const commonProps = {

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -68,7 +68,6 @@ export const TextField = ({
     readOnly: isReadOnly,
     disabled,
     required,
-    'aria-readonly': isReadOnly,
     className: cn(classes['input-wrapper__field'], rest.className),
     style: {
       textAlign: formatting?.align,

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -91,6 +91,7 @@ export const TextField = ({
           {...rest}
           data-testid={`${id}-formatted-number-${variant}`}
           onValueChange={handleNumberFormatChange}
+          isNumericString={true}
         />
       ) : (
         <input

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -13,14 +13,10 @@ import { Icon } from './Icon';
 import classes from './TextField.module.css';
 
 export interface TextFieldProps
-  extends Omit<
-    React.InputHTMLAttributes<HTMLInputElement>,
-    'readOnly' | 'value'
-  > {
+  extends Omit<NumberFormatProps, 'readOnly' | 'value'> {
   value?: string;
   isValid?: boolean;
   readOnly?: boolean | ReadOnlyVariant;
-  ariaDescribedBy?: string;
   formatting?: TextFieldFormatting;
 }
 
@@ -43,15 +39,11 @@ const replaceTargetValueWithUnformattedValue = ({
 
 export const TextField = ({
   id,
-  value,
   onChange,
-  onBlur,
-  onPaste,
   isValid = true,
   disabled = false,
   readOnly = false,
   required = false,
-  ariaDescribedBy,
   formatting,
   ...rest
 }: TextFieldProps) => {
@@ -71,17 +63,14 @@ export const TextField = ({
 
   const commonProps = {
     id,
-    value,
-    onBlur,
-    onPaste,
     readOnly: isReadOnly,
     disabled,
     required,
-    'aria-describedby': ariaDescribedBy,
     'aria-readonly': isReadOnly,
-    className: classes['input-wrapper__field'],
+    className: cn(classes['input-wrapper__field'], rest.className),
     style: {
       textAlign: formatting?.align,
+      ...rest.style,
     },
   };
 
@@ -97,13 +86,14 @@ export const TextField = ({
         <NumberFormat
           {...commonProps}
           {...formatting.number}
+          {...rest}
           data-testid={`${id}-formatted-number-${variant}`}
           onValueChange={handleNumberFormatChange}
         />
       ) : (
         <input
-          {...rest}
           {...commonProps}
+          {...rest}
           data-testid={`${id}-${variant}`}
           onChange={onChange}
         />

--- a/yarn.lock
+++ b/yarn.lock
@@ -88,8 +88,8 @@ __metadata:
     webpack: ^5.74.0
     yargs: ^17.5.1
   peerDependencies:
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION

## Description
- Spread `rest`-props last
- Spread `rest`-props to `NumberFormat` component as well
- Remove `ariaDescribedBy` prop, this can instead be set with `aria-describedby`
- `NumberFormat` component previously triggered `onChange` on rerender as well, which caused issues since we were trying to overwrite the `value` on the `event.target` which would be null on rerender. Now we only trigger `onChange` if the source of the change is from an event.
- Update peerDependency to require React 18. This was not introduced in this PR, but we have been using React 18 features for a little while now, but forgotten to update this requirement.

## Related Issue(s)
- https://github.com/Altinn/app-frontend-react/pull/328

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
