### PR TITLE
fix: show focus outline when focusing TextField in readonly mode

### DIFF
--- a/src/components/TextField/TextField.module.css
+++ b/src/components/TextField/TextField.module.css
@@ -13,14 +13,11 @@
 }
 
 .input-wrapper:focus-within {
+  --border-color: var(--component-input-color-border-focus);
+  --outline-color: var(--border-color);
   outline-style: solid;
   outline-width: var(--component-input-border_width-default);
   outline-color: var(--outline-color);
-}
-
-.input-wrapper--default:focus-within {
-  --border-color: var(--component-input-color-border-focus);
-  --outline-color: var(--border-color);
 }
 
 .input-wrapper--default:hover {


### PR DESCRIPTION
## Description
- Make TextField have a focus outline when focused, even when field is `readonly`, ref https://github.com/Altinn/app-frontend-react/pull/328#issuecomment-1206268388

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
