### PR TITLE
fix: map component calls onClick even when map is readonly

### DIFF
--- a/src/components/Map/Map.test.tsx
+++ b/src/components/Map/Map.test.tsx
@@ -39,6 +39,18 @@ describe('Map', () => {
       } as Location);
     });
 
+    it('should not call mapClicked when readOnly is true and map is clicked', async () => {
+      const handleMapClicked = jest.fn();
+      render({
+        onClick: handleMapClicked,
+        readOnly: true,
+      });
+
+      await clickMap();
+
+      expect(handleMapClicked).not.toHaveBeenCalled();
+    });
+
     it('should get different coordinates when map is clicked at different location', async () => {
       const mapClicked = jest.fn();
       render({

--- a/src/components/Map/Map.test.tsx
+++ b/src/components/Map/Map.test.tsx
@@ -25,7 +25,7 @@ describe('Map', () => {
   });
 
   describe('Click map', () => {
-    it('should call mapClicked with correct coordinates when map is clicked', async () => {
+    it('should call onClick with correct coordinates when map is clicked', async () => {
       const handleMapClicked = jest.fn();
       render({
         onClick: handleMapClicked,
@@ -39,7 +39,7 @@ describe('Map', () => {
       } as Location);
     });
 
-    it('should not call mapClicked when readOnly is true and map is clicked', async () => {
+    it('should not call onClick when readOnly is true and map is clicked', async () => {
       const handleMapClicked = jest.fn();
       render({
         onClick: handleMapClicked,

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -83,30 +83,17 @@ export const Map = ({
         />
       ))}
       <AttributionControl prefix={false} />
-      <LocationMarker
-        location={markerLocation}
+      <LocationMarker markerLocation={markerLocation} />
+      <MapClickHandler
+        readOnly={readOnly}
         onClick={onClick}
       />
     </MapContainer>
   );
 };
 
-interface LocationMarkerProps {
-  location?: Location;
-  onClick?: (location: Location) => void;
-}
-function LocationMarker({ location, onClick }: LocationMarkerProps) {
-  useMapEvents({
-    click(me) {
-      if (onClick) {
-        onClick({
-          latitude: me.latlng.lat,
-          longitude: me.latlng.lng,
-        });
-      }
-    },
-  });
-
+type LocationMarkerProps = Pick<MapProps, 'markerLocation'>;
+function LocationMarker({ markerLocation }: LocationMarkerProps) {
   const markerIcon = icon({
     iconUrl: UrlIcon,
     iconRetinaUrl: RetinaUrlIcon,
@@ -115,9 +102,9 @@ function LocationMarker({ location, onClick }: LocationMarkerProps) {
     iconAnchor: [12, 41],
   });
 
-  return location ? (
+  return markerLocation ? (
     <Marker
-      position={locationToTuple(location)}
+      position={locationToTuple(markerLocation)}
       icon={markerIcon}
     />
   ) : null;
@@ -126,3 +113,19 @@ function LocationMarker({ location, onClick }: LocationMarkerProps) {
 function locationToTuple(location: Location): [number, number] {
   return [location.latitude, location.longitude];
 }
+
+type MapClickHandlerProps = Pick<MapProps, 'readOnly' | 'onClick'>;
+const MapClickHandler = ({ onClick, readOnly }: MapClickHandlerProps) => {
+  useMapEvents({
+    click: (map) => {
+      if (onClick && !readOnly) {
+        onClick({
+          latitude: map.latlng.lat,
+          longitude: map.latlng.lng,
+        });
+      }
+    },
+  });
+
+  return null;
+};


### PR DESCRIPTION
## Description
- fixes issue where map calls onClick even when map is readonly
- minor refactoring:
	- move onClick handler to separate component, not related to LocationMarker, since its really tied to the map and not the LocationMarker itself
	- reuse types from MapProps to ensure we keep the same interface (optional vs required props f.ex)

## Related Issue(s)
- #60 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
