### PR TITLE
Fix screen reader bug for circular progress

### DIFF
--- a/src/components/CircularProgress/CircularProgress.tsx
+++ b/src/components/CircularProgress/CircularProgress.tsx
@@ -28,7 +28,6 @@ export const CircularProgress = ({
       id={id}
       className={classes.container}
       style={{ width: `${width}px` }}
-      aria-valuenow={value}
       role='progressbar'
       aria-labelledby={ariaLabelledby}
       aria-label={ariaLabel}


### PR DESCRIPTION
Remove aria-value now because this value had no extra information for screen readers. It only made things worse when the value had many decimals, it would read a long decimal number. The aria label should be good enough for screen reader to understand.

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #125

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
