### PR TITLE
Add CheckboxGroup component

### DIFF
--- a/src/components/Checkbox/Checkbox.module.css
+++ b/src/components/Checkbox/Checkbox.module.css
@@ -1,15 +1,21 @@
 .wrapper {
-  align-items: center;
   border-radius: var(--interactive_components-border_radius-normal);
   cursor: pointer;
   display: inline-flex;
-  flex-direction: row;
+  flex-direction: column;
   font-size: var(--component-checkbox-font_size-normal);
   gap: var(--component-checkbox-space-gap-normal);
 }
 
 .wrapper:not(.wrapper--disabled):not(.wrapper--read-only) {
   cursor: pointer;
+}
+
+.checkbox-and-label {
+  align-items: center;
+  display: inline-flex;
+  flex-direction: row;
+  gap: var(--component-checkbox-space-gap-normal);
 }
 
 .checkbox-wrapper {
@@ -53,6 +59,14 @@
   display: inline-block;
   height: 100%;
   width: 100%;
+}
+
+.description {
+  color: var(--colors-neutral-600);
+  margin-left: calc(
+    var(--component-checkbox-size-width-normal) +
+      var(--component-checkbox-space-gap-normal)
+  );
 }
 
 .wrapper:not(.wrapper--checked) .visible-box__checkmark {
@@ -120,6 +134,10 @@
   gap: var(--component-checkbox-space-gap-compact);
 }
 
+.wrapper--compact .checkbox-and-label {
+  gap: var(--component-checkbox-space-gap-compact);
+}
+
 .wrapper--compact .checkbox-wrapper,
 .wrapper--compact .visible-box {
   height: var(--component-checkbox-size-height-compact);
@@ -128,6 +146,13 @@
 
 .wrapper--compact .visible-box {
   border-width: var(--component-checkbox-border_width-compact);
+}
+
+.wrapper--compact .description {
+  margin-left: calc(
+    var(--component-checkbox-size-width-compact) +
+      var(--component-checkbox-space-gap-compact)
+  );
 }
 
 .wrapper--read-only {

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -103,3 +103,13 @@ ReadOnly.parameters = {
     },
   },
 };
+
+export const WithDescription = Template.bind({});
+WithDescription.args = { description: 'Lorem ipsum dolor sit amet.' };
+WithDescription.parameters = {
+  docs: {
+    description: {
+      story: 'This is a checkbox with description.',
+    },
+  },
+};

--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -65,6 +65,12 @@ describe('Checkbox', () => {
     const checkbox = screen.getByRole('checkbox');
     expect(checkbox.getAttribute('name')).toEqual(name);
   });
+
+  it('Should display description', () => {
+    const description = 'Lorem ipsum dolor sit amet';
+    render({ description });
+    expect(screen.getByText(description)).toBeDefined();
+  });
 });
 
 const render = (props: Partial<CheckboxProps> = {}) => {

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -31,6 +31,8 @@ export const Checkbox = ({
 }: CheckboxProps) => {
   const randomId = useId();
   const inputId = checkboxId || 'checkbox-' + randomId;
+  const labelId = label ? `${inputId}-label` : undefined;
+  const descriptionId = description ? `${inputId}-description` : undefined;
 
   return (
     <label
@@ -48,6 +50,8 @@ export const Checkbox = ({
         {!readOnly && (
           <span className={classes['checkbox-wrapper']}>
             <input
+              aria-describedby={descriptionId}
+              aria-labelledby={labelId}
               checked={checked ?? false}
               className={classes.checkbox}
               disabled={disabled}
@@ -61,10 +65,22 @@ export const Checkbox = ({
             </span>
           </span>
         )}
-        {label && <span className={classes.label}>{label}</span>}
+        {label && (
+          <span
+            className={classes.label}
+            id={`${inputId}-label`}
+          >
+            {label}
+          </span>
+        )}
       </span>
       {description && (
-        <span className={classes['description']}>{description}</span>
+        <span
+          className={classes['description']}
+          id={`${inputId}-description`}
+        >
+          {description}
+        </span>
       )}
     </label>
   );

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -8,6 +8,7 @@ export interface CheckboxProps {
   checkboxId?: string;
   checked?: boolean;
   compact?: boolean;
+  description?: string;
   disabled?: boolean;
   error?: boolean;
   label?: string;
@@ -20,6 +21,7 @@ export const Checkbox = ({
   checkboxId,
   checked,
   compact,
+  description,
   disabled,
   error,
   label,
@@ -42,23 +44,28 @@ export const Checkbox = ({
       )}
       htmlFor={inputId}
     >
-      {!readOnly && (
-        <span className={classes['checkbox-wrapper']}>
-          <input
-            checked={checked ?? false}
-            className={classes.checkbox}
-            disabled={disabled}
-            id={inputId}
-            name={name}
-            onChange={disabled ? undefined : onChange}
-            type='checkbox'
-          />
-          <span className={classes['visible-box']}>
-            <span className={classes['visible-box__checkmark']} />
+      <span className={classes['checkbox-and-label']}>
+        {!readOnly && (
+          <span className={classes['checkbox-wrapper']}>
+            <input
+              checked={checked ?? false}
+              className={classes.checkbox}
+              disabled={disabled}
+              id={inputId}
+              name={name}
+              onChange={disabled ? undefined : onChange}
+              type='checkbox'
+            />
+            <span className={classes['visible-box']}>
+              <span className={classes['visible-box__checkmark']} />
+            </span>
           </span>
-        </span>
+        )}
+        {label && <span className={classes.label}>{label}</span>}
+      </span>
+      {description && (
+        <span className={classes['description']}>{description}</span>
       )}
-      {label && <span className={classes.label}>{label}</span>}
     </label>
   );
 };

--- a/src/components/CheckboxGroup/CheckboxGroup.module.css
+++ b/src/components/CheckboxGroup/CheckboxGroup.module.css
@@ -1,0 +1,85 @@
+.wrapper {
+  font-size: var(--component-checkbox-font_size-normal);
+}
+
+.checkbox-group {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.checkbox-group legend {
+  font-weight: bold;
+  padding: 0;
+}
+
+.checkbox-group__description {
+  margin-top: 0;
+}
+
+.checkbox-group legend,
+.checkbox-group__description {
+  margin-bottom: var(--component-checkbox-group-space-gap-y-normal);
+}
+
+.checkbox-group__list {
+  column-gap: var(--component-checkbox-group-space-gap-x-normal);
+  display: flex;
+  flex-wrap: wrap;
+  row-gap: var(--component-checkbox-group-space-gap-y-normal);
+}
+
+.checkbox-group__list--vertical {
+  flex-direction: column;
+}
+
+.checkbox-group__list--horisontal {
+  flex-direction: row;
+}
+
+.checkbox-group__error-message {
+  margin-top: var(--component-checkbox-group-space-gap-y-normal);
+}
+
+.wrapper--error {
+  align-items: stretch;
+  display: flex;
+}
+
+.wrapper--error__line {
+  /* This will make a line appear to the left of the fieldset without affecting the position of anything. */
+  flex: 0;
+  left: -2rem;
+  outline: 1px solid var(--component-checkbox-color-border-error);
+  position: relative;
+}
+
+.wrapper--disabled {
+  color: var(--component-checkbox-color-text-disabled);
+}
+
+.wrapper--compact {
+  font-size: var(--component-checkbox-font_size-compact);
+}
+
+.wrapper--compact .wrapper--error__line {
+  left: -1rem;
+}
+
+.wrapper--compact legend,
+.wrapper--compact .checkbox-group__description {
+  margin-bottom: var(--component-checkbox-group-space-gap-y-compact);
+}
+
+.wrapper--compact .checkbox-group__list {
+  column-gap: var(--component-checkbox-group-space-gap-x-compact);
+  row-gap: var(--component-checkbox-group-space-gap-y-compact);
+}
+
+.wrapper--compact legend {
+  margin-bottom: var(--component-checkbox-group-space-gap-y-compact);
+}
+
+.wrapper--compact .checkbox-group__error-message {
+  margin-top: var(--component-checkbox-group-space-gap-y-compact);
+}

--- a/src/components/CheckboxGroup/CheckboxGroup.module.css
+++ b/src/components/CheckboxGroup/CheckboxGroup.module.css
@@ -8,7 +8,7 @@
   padding: 0;
 }
 
-.checkbox-group legend {
+.checkbox-group__legend {
   font-weight: bold;
   padding: 0;
 }
@@ -17,7 +17,7 @@
   margin-top: 0;
 }
 
-.checkbox-group legend,
+.checkbox-group__legend,
 .checkbox-group__description {
   margin-bottom: var(--component-checkbox-group-space-gap-y-normal);
 }
@@ -33,7 +33,7 @@
   flex-direction: column;
 }
 
-.checkbox-group__list--horisontal {
+.checkbox-group__list--horizontal {
   flex-direction: row;
 }
 
@@ -66,7 +66,7 @@
   left: -1rem;
 }
 
-.wrapper--compact legend,
+.wrapper--compact .checkbox-group__legend,
 .wrapper--compact .checkbox-group__description {
   margin-bottom: var(--component-checkbox-group-space-gap-y-compact);
 }
@@ -76,7 +76,7 @@
   row-gap: var(--component-checkbox-group-space-gap-y-compact);
 }
 
-.wrapper--compact legend {
+.wrapper--compact .checkbox-group__legend {
   margin-bottom: var(--component-checkbox-group-space-gap-y-compact);
 }
 

--- a/src/components/CheckboxGroup/CheckboxGroup.stories.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.stories.tsx
@@ -69,14 +69,14 @@ Vertical.parameters = {
   },
 };
 
-export const Horisontal = Template.bind({});
-Horisontal.args = {
-  variant: CheckboxGroupVariant.Horisontal,
+export const Horizontal = Template.bind({});
+Horizontal.args = {
+  variant: CheckboxGroupVariant.Horizontal,
 };
-Horisontal.parameters = {
+Horizontal.parameters = {
   docs: {
     description: {
-      story: 'Use this if there is sufficient horisontal space.',
+      story: 'Use this if there is sufficient horizontal space.',
     },
   },
 };

--- a/src/components/CheckboxGroup/CheckboxGroup.stories.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.stories.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import { config } from 'storybook-addon-designs';
+
+import { StoryPage } from '@sb/StoryPage';
+
+import { CheckboxGroup, CheckboxGroupVariant } from './CheckboxGroup';
+
+const figmaLink =
+  'https://www.figma.com/file/vpM9dqqQPHqU6ogfKp5tlr/DDS---Core-Components?node-id=6632%3A21455';
+
+export default {
+  title: `Components/CheckboxGroup`,
+  component: CheckboxGroup,
+  parameters: {
+    design: config([
+      {
+        type: 'figma',
+        url: figmaLink,
+      },
+      {
+        type: 'link',
+        url: figmaLink,
+      },
+    ]),
+    docs: {
+      page: () => (
+        <StoryPage
+          description={
+            'Group of checkboxes for use cases where the user should be able to choose multiple answers from a list of given values. ' +
+            "Its `onChange` prop can be set to a function that will be called with a list of the selected checkboxes' names each time something changes."
+          }
+        />
+      ),
+    },
+  },
+  args: {
+    compact: false,
+    description: 'Velg én eller flere planeter fra listen.',
+    disabled: false,
+    items: [
+      { checked: false, label: 'Merkur', name: 'planet1' },
+      { checked: false, label: 'Venus', name: 'planet2' },
+      { checked: false, label: 'Jorden', name: 'planet3' },
+      { checked: false, label: 'Mars', name: 'planet4' },
+      { checked: false, label: 'Jupiter', name: 'planet5' },
+      { checked: false, label: 'Saturn', name: 'planet6' },
+      { checked: false, label: 'Uranus', name: 'planet7' },
+      { checked: false, label: 'Neptun', name: 'planet8' },
+    ],
+    legend: 'Velg planeter',
+    variant: CheckboxGroupVariant.Vertical,
+  },
+} as ComponentMeta<typeof CheckboxGroup>;
+
+const Template: ComponentStory<typeof CheckboxGroup> = (args) => (
+  <CheckboxGroup {...args} />
+);
+
+export const Vertical = Template.bind({});
+Vertical.args = {
+  variant: CheckboxGroupVariant.Vertical,
+};
+Vertical.parameters = {
+  docs: {
+    description: {
+      story: 'This is the default setting.',
+    },
+  },
+};
+
+export const Horisontal = Template.bind({});
+Horisontal.args = {
+  variant: CheckboxGroupVariant.Horisontal,
+};
+Horisontal.parameters = {
+  docs: {
+    description: {
+      story: 'Use this if there is sufficient horisontal space.',
+    },
+  },
+};
+
+export const Compact = Template.bind({});
+Compact.args = {
+  compact: true,
+};
+Compact.parameters = {
+  docs: {
+    description: {
+      story:
+        'Use this if there are space limitations or if the content is less important.',
+    },
+  },
+};
+
+export const Error = Template.bind({});
+Error.args = {
+  error: 'Noe er galt.',
+};
+Error.parameters = {
+  docs: {
+    description: {
+      story:
+        'The checkbox group gets this state if the `error` property is set. Use it to tell the user that there is an input error related to this group.',
+    },
+  },
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+  disabled: true,
+};
+Disabled.parameters = {
+  docs: {
+    description: {
+      story:
+        'Use this if the user is not supposed to change the values. Remember to make it clear for the user why they can not be changed.',
+    },
+  },
+};

--- a/src/components/CheckboxGroup/CheckboxGroup.test.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.test.tsx
@@ -131,13 +131,15 @@ describe('CheckboxGroup', () => {
 
   it('Checkboxes should be rendered with the properties given in the "items" prop', () => {
     const description = 'Description',
-      id = 'id',
+      checkboxId = 'id',
       label = 'Label',
       name = 'name';
-    render({ items: [{ description, disabled: true, id, label, name }] });
+    render({
+      items: [{ description, disabled: true, checkboxId, label, name }],
+    });
     const checkbox = screen.getByRole('checkbox');
     expect(checkbox.getAttribute('name')).toEqual(name);
-    expect(checkbox.getAttribute('id')).toEqual(id);
+    expect(checkbox.getAttribute('id')).toEqual(checkboxId);
     expect(checkbox).toBeDisabled();
     expect(screen.getByText(label)).toBeDefined();
     expect(screen.getByText(description)).toBeDefined();

--- a/src/components/CheckboxGroup/CheckboxGroup.test.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.test.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { act, render as renderRtl, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { CheckboxGroup } from '@/components';
+
+import type { CheckboxGroupProps } from './CheckboxGroup';
+
+const user = userEvent.setup();
+
+const defaultProps: CheckboxGroupProps = {
+  items: [
+    { label: 'Test 1', name: 'test1' },
+    { label: 'Test 2', name: 'test2' },
+  ],
+};
+
+describe('CheckboxGroup', () => {
+  it('Should display a checkbox for each item', () => {
+    render();
+    expect(screen.queryAllByRole('checkbox')).toHaveLength(
+      defaultProps.items.length,
+    );
+  });
+
+  it('Should display legend', () => {
+    const legend = 'Lorem ipsum';
+    render({ legend });
+    expect(screen.getByText(legend)).toBeDefined();
+  });
+
+  it('Should display description', () => {
+    const description = 'Lorem ipsum dolor sit amet';
+    render({ description });
+    expect(screen.getByText(description)).toBeDefined();
+  });
+
+  it('Should display error message if given', () => {
+    const error = 'Something is wrong';
+    render({ error });
+    expect(screen.getByText(error)).toBeDefined();
+  });
+
+  it('Should throw an error if there are duplicate names', () => {
+    const renderFn = () =>
+      render({
+        items: [
+          { label: 'Test 1', name: 'duplicated name' },
+          { label: 'Test 2', name: 'duplicated name' },
+        ],
+      });
+    jest.spyOn(console, 'error').mockImplementation(jest.fn()); // Keeps the console output clean
+    expect(renderFn).toThrow('Each name in the checkbox group must be unique.');
+  });
+
+  it('Should call onChange handler with an array of the selected names when a checkbox is checked', async () => {
+    const onChange = jest.fn();
+    render({ onChange });
+    await act(() => user.click(screen.queryAllByRole('checkbox')[0]));
+    expect(onChange).toHaveBeenCalledWith([defaultProps.items[0].name]);
+  });
+
+  it('Checkboxes should be checked if the "items" prop tells them to be', () => {
+    render({
+      items: [
+        { checked: false, label: 'Test 1', name: 'test1' },
+        { checked: true, label: 'Test 2', name: 'test2' },
+      ],
+    });
+    const checkboxes = screen.queryAllByRole('checkbox');
+    expect(checkboxes[0]).not.toBeChecked();
+    expect(checkboxes[1]).toBeChecked();
+  });
+
+  it('Checkboxes should update their "checked" state if the component rerenders with another configuration', () => {
+    const { rerender } = render();
+    rerender(
+      <CheckboxGroup
+        items={[
+          { checked: true, label: 'Test 1', name: 'test1' },
+          { checked: false, label: 'Test 2', name: 'test2' },
+        ]}
+      />,
+    );
+    const checkboxes = screen.queryAllByRole('checkbox');
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).not.toBeChecked();
+  });
+
+  it('Checkboxes should not be checked by default', () => {
+    render();
+    const checkboxes = screen.queryAllByRole('checkbox');
+    checkboxes.forEach((checkbox) => expect(checkbox).not.toBeChecked());
+  });
+
+  it('Checkboxes should not be disabled by default', () => {
+    render();
+    const checkboxes = screen.queryAllByRole('checkbox');
+    checkboxes.forEach((checkbox) => expect(checkbox).not.toBeDisabled());
+  });
+
+  it('Should switch "checked" state of a checkbox when the user clicks on it', async () => {
+    render();
+    const checkboxes = screen.queryAllByRole('checkbox');
+    await act(() => user.click(checkboxes[0]));
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).not.toBeChecked();
+    await act(() => user.click(checkboxes[1]));
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).toBeChecked();
+    await act(() => user.click(checkboxes[0]));
+    expect(checkboxes[0]).not.toBeChecked();
+    expect(checkboxes[1]).toBeChecked();
+    await act(() => user.click(checkboxes[1]));
+    expect(checkboxes[0]).not.toBeChecked();
+    expect(checkboxes[1]).not.toBeChecked();
+  });
+
+  it('All checkboxes should be disabled when the "disabled" prop is true', () => {
+    render({ disabled: true });
+    const checkboxes = screen.queryAllByRole('checkbox');
+    checkboxes.forEach((checkbox) => expect(checkbox).toBeDisabled());
+  });
+
+  it('onChange handler should not be called when the "disabled" prop is true', async () => {
+    const onChange = jest.fn();
+    render({ disabled: true, onChange });
+    await act(() => user.click(screen.queryAllByRole('checkbox')[0]));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('Checkboxes should be rendered with the properties given in the "items" prop', () => {
+    const description = 'Description',
+      id = 'id',
+      label = 'Label',
+      name = 'name';
+    render({ items: [{ description, disabled: true, id, label, name }] });
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox.getAttribute('name')).toEqual(name);
+    expect(checkbox.getAttribute('id')).toEqual(id);
+    expect(checkbox).toBeDisabled();
+    expect(screen.getByText(label)).toBeDefined();
+    expect(screen.getByText(description)).toBeDefined();
+  });
+});
+
+const render = (props: Partial<CheckboxGroupProps> = {}) => {
+  const allProps = { ...defaultProps, ...props };
+  return renderRtl(<CheckboxGroup {...allProps} />);
+};

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -2,21 +2,19 @@ import React, { useEffect, useId, useReducer } from 'react';
 import cn from 'classnames';
 
 import { Checkbox, ErrorMessage } from '@/components';
+import type { CheckboxProps } from '@/components/Checkbox/Checkbox';
 
 import classes from './CheckboxGroup.module.css';
 
-export interface CheckboxItem {
-  checked?: boolean;
-  description?: string;
-  disabled?: boolean;
-  id?: string;
-  label?: string;
-  name: string;
-}
+export type CheckboxItem = Pick<
+  CheckboxProps,
+  'checked' | 'description' | 'disabled' | 'checkboxId' | 'label'
+> &
+  Required<Pick<CheckboxProps, 'name'>>;
 
 export enum CheckboxGroupVariant {
   Vertical = 'vertical',
-  Horisontal = 'horisontal',
+  Horizontal = 'horizontal',
 }
 
 export type CheckedNames = string[];
@@ -89,7 +87,11 @@ export const CheckboxGroup = ({
     >
       {error && <div className={classes['wrapper--error__line']} />}
       <fieldset className={classes['checkbox-group']}>
-        {legend && <legend>{legend}</legend>}
+        {legend && (
+          <legend className={classes['checkbox-group__legend']}>
+            {legend}
+          </legend>
+        )}
         {description && (
           <p className={classes['checkbox-group__description']}>
             {description}
@@ -104,7 +106,7 @@ export const CheckboxGroup = ({
           {items.map((item, index) => (
             <div key={`checkbox-group-${randomId}-${index}`}>
               <Checkbox
-                checkboxId={item.id}
+                checkboxId={item.checkboxId}
                 checked={checkedNames.includes(item.name)}
                 compact={compact}
                 description={item.description}

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useId, useReducer } from 'react';
+import cn from 'classnames';
+
+import { Checkbox, ErrorMessage } from '@/components';
+
+import classes from './CheckboxGroup.module.css';
+
+export interface CheckboxItem {
+  checked?: boolean;
+  description?: string;
+  disabled?: boolean;
+  id?: string;
+  label?: string;
+  name: string;
+}
+
+export enum CheckboxGroupVariant {
+  Vertical = 'vertical',
+  Horisontal = 'horisontal',
+}
+
+export type CheckedNames = string[];
+
+export interface CheckboxGroupProps {
+  compact?: boolean;
+  description?: string;
+  disabled?: boolean;
+  error?: string;
+  items: CheckboxItem[];
+  legend?: string;
+  onChange?: (names: CheckedNames) => void;
+  variant?: CheckboxGroupVariant;
+}
+
+type ReducerAction =
+  | { type: 'check' | 'uncheck'; name: string }
+  | { type: 'reset'; state: CheckedNames };
+
+const reducer = (state: CheckedNames, action: ReducerAction) => {
+  switch (action.type) {
+    case 'check':
+      return state.concat([action.name]);
+    case 'uncheck':
+      return state.filter((name) => name !== action.name);
+    case 'reset':
+      return action.state;
+  }
+};
+const checkedItems = (items: CheckboxItem[]) =>
+  items.filter(({ checked }) => checked).map(({ name }) => name);
+
+export const CheckboxGroup = ({
+  compact,
+  description,
+  disabled,
+  error,
+  items,
+  legend,
+  onChange,
+  variant = CheckboxGroupVariant.Vertical,
+}: CheckboxGroupProps) => {
+  const allNames = items.map((item) => item.name);
+  if (allNames.length !== new Set(allNames).size) {
+    throw Error('Each name in the checkbox group must be unique.');
+  }
+
+  const randomId = useId();
+
+  const [checkedNames, dispatch] = useReducer(reducer, checkedItems(items));
+
+  useEffect(
+    () => dispatch({ type: 'reset', state: checkedItems(items) }),
+    [items],
+  );
+
+  useEffect(
+    () => (onChange && !disabled ? onChange(checkedNames) : undefined),
+    [checkedNames, onChange, disabled],
+  );
+
+  return (
+    <div
+      className={cn(
+        classes.wrapper,
+        error && classes['wrapper--error'],
+        compact && classes['wrapper--compact'],
+        disabled && classes['wrapper--disabled'],
+      )}
+    >
+      {error && <div className={classes['wrapper--error__line']} />}
+      <fieldset className={classes['checkbox-group']}>
+        {legend && <legend>{legend}</legend>}
+        {description && (
+          <p className={classes['checkbox-group__description']}>
+            {description}
+          </p>
+        )}
+        <div
+          className={cn(
+            classes['checkbox-group__list'],
+            classes[`checkbox-group__list--${variant}`],
+          )}
+        >
+          {items.map((item, index) => (
+            <div key={`checkbox-group-${randomId}-${index}`}>
+              <Checkbox
+                checkboxId={item.id}
+                checked={checkedNames.includes(item.name)}
+                compact={compact}
+                description={item.description}
+                disabled={disabled || item.disabled}
+                error={!!error}
+                label={item.label}
+                name={item.name}
+                onChange={(event) => {
+                  dispatch({
+                    type: event.target.checked ? 'check' : 'uncheck',
+                    name: item.name,
+                  });
+                }}
+              />
+            </div>
+          ))}
+        </div>
+        {error && (
+          <div className={classes['checkbox-group__error-message']}>
+            <ErrorMessage>{error}</ErrorMessage>
+          </div>
+        )}
+      </fieldset>
+    </div>
+  );
+};

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -23,7 +23,7 @@ export interface CheckboxGroupProps {
   compact?: boolean;
   description?: string;
   disabled?: boolean;
-  error?: string;
+  error?: React.ReactNode;
   items: CheckboxItem[];
   legend?: string;
   onChange?: (names: CheckedNames) => void;
@@ -102,24 +102,23 @@ export const CheckboxGroup = ({
           )}
         >
           {items.map((item) => (
-            <div key={item.name}>
-              <Checkbox
-                checkboxId={item.checkboxId}
-                checked={checkedNames.includes(item.name)}
-                compact={compact}
-                description={item.description}
-                disabled={disabled || item.disabled}
-                error={!!error}
-                label={item.label}
-                name={item.name}
-                onChange={(event) => {
-                  dispatch({
-                    type: event.target.checked ? 'check' : 'uncheck',
-                    name: item.name,
-                  });
-                }}
-              />
-            </div>
+            <Checkbox
+              checkboxId={item.checkboxId}
+              checked={checkedNames.includes(item.name)}
+              compact={compact}
+              description={item.description}
+              disabled={disabled || item.disabled}
+              error={!!error}
+              key={item.name}
+              label={item.label}
+              name={item.name}
+              onChange={(event) => {
+                dispatch({
+                  type: event.target.checked ? 'check' : 'uncheck',
+                  name: item.name,
+                });
+              }}
+            />
           ))}
         </div>
         {error && (

--- a/src/components/CheckboxGroup/index.ts
+++ b/src/components/CheckboxGroup/index.ts
@@ -1,0 +1,1 @@
+export { CheckboxGroup } from './CheckboxGroup';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -19,3 +19,4 @@ export { Map } from './Map';
 export { Checkbox } from './Checkbox';
 export { TextArea } from './TextArea';
 export type { IconVariant, ReadOnlyVariant } from './_InputWrapper';
+export { CheckboxGroup } from './CheckboxGroup';


### PR DESCRIPTION
## Description
Component that groups checkboxes into a multiple choice view. I have also added a `description` prop to the `Checkbox` component, to make it easy to add a description to each checkbox.

## Related Issue(s)
- #142 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
