### PR TITLE
Set line height in Accordion header

### DIFF
--- a/src/components/Accordion/AccordionHeader.module.css
+++ b/src/components/Accordion/AccordionHeader.module.css
@@ -57,6 +57,7 @@
   font-size: var(--component-accordion_header_title-font_size);
   font-weight: var(--component-accordion_header_title-font_weight);
   margin-left: var(--component-accordion_header_title-spacing-margin_left);
+  line-height: 16px;
 }
 
 .accordion-header__actions {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Right now, the line height is not set in the accordion header, meaning that the component might look different when in use than it does in storybook. The component shouldn't have an arbitrary look depending on some unknown value. Thus, we set the line-height in the component.

It is set to 16 because that is what the component was designed with.
