### PR TITLE
Updated react-number-format to 5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@react-hookz/web": "^15.0.1",
     "leaflet": "^1.8.0",
     "react-leaflet": "^4.0.1",
-    "react-number-format": "^4.9.3"
+    "react-number-format": "^5.0.1"
   },
   "resolutions": {
     "@storybook/react/webpack": "^5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,7 +85,7 @@ __metadata:
     react: 18.2.0
     react-dom: 18.2.0
     react-leaflet: ^4.0.1
-    react-number-format: ^4.9.3
+    react-number-format: ^5.0.1
     rollup: 2.79.1
     rollup-plugin-dts: 4.2.2
     rollup-plugin-peer-deps-external: 2.2.4
@@ -16409,15 +16409,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-number-format@npm:^4.9.3":
-  version: 4.9.4
-  resolution: "react-number-format@npm:4.9.4"
+"react-number-format@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "react-number-format@npm:5.0.1"
   dependencies:
     prop-types: ^15.7.2
   peerDependencies:
-    react: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
-  checksum: 61df4ce5fecfcd3424309af65928327aebbe80094cda28941da324995e49152d71b28fedb4c6494ca2fdfb9be1879032da9077f4d33a41ecc999f251c604d5c9
+    react: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^18.0.0
+    react-dom: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^18.0.0
+  checksum: 140c3bcf57b434e25ded93e0191dfaead11d767d7d54909ca163f49bc5837a975b85baf803932e17388d3a674cf1b52cf1d1b4f7c9b8c4f64515c624421c4939
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updated `react-number-format` to a new major version (v5). This contains several breaking changes, so the `TextField` component had to be updated accordingly. Luckily, it looks like it will be fully compatible with app-frontend, so that no changes will be necessary there or in any existing apps. This version fixes the issue mentioned with suffixes; unfortunately, it also introduces a new similar bug also related to suffixes (the other linked issue is related to this).

These new issues have been mitigated by modifying the behavior of the keyDown event in the `numericKeyDown` function. I discovered another issue which was present in the old version as well. If you start a prefix with `-`, a lot of weird behavior occurs since `react-number-format` under the hood checks the first character to determine whether the number is negative.

Added some unit tests to verify this behavior, have confirmed that they fail for v4 and v5 without the fixes above. Have also tested all frontend tests using this version of altinn-design-system and its all green ✅ 

## Related Issue(s)
- Altinn/app-frontend-react#294
- https://github.com/s-yadav/react-number-format/issues/694

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- ~~User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
