### PR TITLE
Add field set component

### DIFF
--- a/src/components/CheckboxGroup/CheckboxGroup.module.css
+++ b/src/components/CheckboxGroup/CheckboxGroup.module.css
@@ -1,31 +1,11 @@
 .checkbox-group {
-  --description-margin_top: var(--component-field_description-space-top-small);
-  --font_size: var(--component-checkbox-font_size-small);
   --gap-x: var(--component-checkbox-group-space-gap-x-small);
   --gap-y: var(--component-checkbox-group-space-gap-y-small);
-
-  border: 0;
-  font-size: var(--font_size);
-  line-height: var(--typography-default-line-height);
-  margin: 0;
-  padding: 0;
 }
 
 .checkbox-group--compact {
-  --description-margin_top: var(--component-field_description-space-top-xsmall);
-  --font_size: var(--component-checkbox-font_size-xsmall);
   --gap-x: var(--component-checkbox-group-space-gap-x-xsmall);
   --gap-y: var(--component-checkbox-group-space-gap-y-xsmall);
-}
-
-.checkbox-group__legend {
-  font-weight: bold;
-  padding: 0;
-}
-
-.checkbox-group__description {
-  color: var(--component-field_description-color-text-default);
-  margin-top: var(--description-margin_top);
 }
 
 .checkbox-group__list {
@@ -41,12 +21,4 @@
 
 .checkbox-group__list--horizontal {
   flex-direction: row;
-}
-
-.checkbox-group__error-message {
-  margin-top: var(--gap-y);
-}
-
-.checkbox-group--disabled {
-  color: var(--component-checkbox-color-text-disabled);
 }

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useReducer } from 'react';
 import cn from 'classnames';
 
-import { Checkbox, ErrorMessage } from '@/components';
+import { Checkbox, FieldSet } from '@/components';
 import type { CheckboxProps } from '@/components/Checkbox/Checkbox';
+import { FieldSetSize } from '@/components/FieldSet/FieldSet';
 
 import classes from './CheckboxGroup.module.css';
 
@@ -75,19 +76,17 @@ export const CheckboxGroup = ({
   );
 
   return (
-    <fieldset
+    <FieldSet
       className={cn(
         classes['checkbox-group'],
         compact && classes['checkbox-group--compact'],
-        disabled && classes['checkbox-group--disabled'],
       )}
+      description={description}
+      disabled={disabled}
+      error={error}
+      legend={legend}
+      size={compact ? FieldSetSize.Xsmall : FieldSetSize.Small}
     >
-      {legend && (
-        <legend className={classes['checkbox-group__legend']}>{legend}</legend>
-      )}
-      {description && (
-        <p className={classes['checkbox-group__description']}>{description}</p>
-      )}
       <div
         className={cn(
           classes['checkbox-group__list'],
@@ -114,11 +113,6 @@ export const CheckboxGroup = ({
           />
         ))}
       </div>
-      {error && (
-        <div className={classes['checkbox-group__error-message']}>
-          <ErrorMessage>{error}</ErrorMessage>
-        </div>
-      )}
-    </fieldset>
+    </FieldSet>
   );
 };

--- a/src/components/FieldSet/FieldSet.module.css
+++ b/src/components/FieldSet/FieldSet.module.css
@@ -1,0 +1,51 @@
+.field-set {
+  --color: var(--component-checkbox-color-text-default);
+  --content-margin_top: var(--component-checkbox-group-space-gap-y-small);
+  --description-color: var(--component-field_description-color-text-default);
+  --description-margin_top: var(--component-field_description-space-top-small);
+  --error_message-margin_top: var(--component-checkbox-group-space-gap-y-small);
+  --font_size: var(--component-checkbox-font_size-small);
+
+  color: var(--color);
+  border: 0;
+  font-size: var(--font_size);
+  line-height: var(--typography-default-line-height);
+  margin: 0;
+  padding: 0;
+}
+
+.field-set--xsmall {
+  --content-margin_top: var(--component-checkbox-group-space-gap-y-xsmall);
+  --description-margin_top: var(--component-field_description-space-top-xsmall);
+  --error_message-margin_top: var(
+    --component-checkbox-group-space-gap-y-xsmall
+  );
+  --font_size: var(--component-checkbox-font_size-xsmall);
+}
+
+.field-set:disabled {
+  --color: var(--component-checkbox-color-text-disabled);
+  --description-color: var(--component-checkbox-color-text-disabled);
+}
+
+.legend {
+  font-weight: bold;
+  padding: 0;
+}
+
+.description {
+  color: var(--description-color);
+  margin: 0;
+}
+
+.legend + .description {
+  margin-top: var(--description-margin_top);
+}
+
+.content:not(:first-child) {
+  margin-top: var(--content-margin_top);
+}
+
+.error-message {
+  margin-top: var(--error_message-margin_top);
+}

--- a/src/components/FieldSet/FieldSet.module.css
+++ b/src/components/FieldSet/FieldSet.module.css
@@ -28,24 +28,24 @@
   --description-color: var(--component-checkbox-color-text-disabled);
 }
 
-.legend {
+.field-set__legend {
   font-weight: bold;
   padding: 0;
 }
 
-.description {
+.field-set__description {
   color: var(--description-color);
   margin: 0;
 }
 
-.legend + .description {
+.field-set__legend + .field-set__description {
   margin-top: var(--description-margin_top);
 }
 
-.content:not(:first-child) {
+.field-set__content:not(:first-child) {
   margin-top: var(--content-margin_top);
 }
 
-.error-message {
+.field-set__error-message {
   margin-top: var(--error_message-margin_top);
 }

--- a/src/components/FieldSet/FieldSet.stories.tsx
+++ b/src/components/FieldSet/FieldSet.stories.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import { config } from 'storybook-addon-designs';
+
+import { StoryPage } from '@sb/StoryPage';
+
+import { FieldSet, FieldSetSize } from './FieldSet';
+
+const figmaLink = '';
+
+export default {
+  title: `Components/FieldSet`,
+  component: FieldSet,
+  parameters: {
+    design: config([
+      {
+        type: 'figma',
+        url: figmaLink,
+      },
+      {
+        type: 'link',
+        url: figmaLink,
+      },
+    ]),
+    docs: {
+      page: () => (
+        <StoryPage
+          description={`Field set component to use as a wrapper for groups of form elements.`}
+        />
+      ),
+    },
+  },
+  args: {
+    children: 'Her er det noe innhold.',
+    legend: 'Lorem ipsum',
+    size: FieldSetSize.Small,
+  },
+} as ComponentMeta<typeof FieldSet>;
+
+const Template: ComponentStory<typeof FieldSet> = (args) => (
+  <FieldSet {...args}>{args.children}</FieldSet>
+);
+
+export const Normal = Template.bind({});
+Normal.args = {};
+Normal.parameters = {
+  docs: {
+    description: {
+      story: 'This is a normal field set.',
+    },
+  },
+};
+
+export const Compact = Template.bind({});
+Compact.args = { size: FieldSetSize.Xsmall };
+Compact.parameters = {
+  docs: {
+    description: {
+      story: 'This is a compact field set.',
+    },
+  },
+};
+
+export const WithDescription = Template.bind({});
+WithDescription.args = {
+  description:
+    'Nulla quis enim at massa pretium accumsan eu sed magna. Sed vehicula.',
+};
+WithDescription.parameters = {
+  docs: {
+    description: {
+      story: 'This is a field set with a description.',
+    },
+  },
+};
+
+export const Error = Template.bind({});
+Error.args = { error: 'Her er det en beskrivende feilmelding.' };
+Error.parameters = {
+  docs: {
+    description: {
+      story:
+        'This is a field set with an error message related to the content.',
+    },
+  },
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = { disabled: true };
+Disabled.parameters = {
+  docs: {
+    description: {
+      story:
+        'This is a disabled field set. All input components inside become disabled.',
+    },
+  },
+};

--- a/src/components/FieldSet/FieldSet.test.tsx
+++ b/src/components/FieldSet/FieldSet.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { render as renderRtl, screen } from '@testing-library/react';
+
+import type { FieldSetProps } from './FieldSet';
+import { FieldSet, FieldSetSize } from './FieldSet';
+
+const defaultProps: FieldSetProps = {
+  children: 'Some content.',
+};
+
+describe('FieldSet', () => {
+  it('Should display children', () => {
+    render();
+    expect(screen.getByText(defaultProps.children as string)).toBeDefined();
+  });
+
+  it('Should not display legend by default', () => {
+    const { container } = render();
+    expect(container.querySelector('legend')).toBeFalsy();
+  });
+
+  it('Should display legend if given', () => {
+    const legend = 'Lorem ipsum';
+    const { container } = render({ legend });
+    expect(container.querySelector('legend')).toHaveTextContent(legend);
+  });
+
+  it('Should not display description by default', () => {
+    const { container } = render();
+    expect(container.querySelector('.description')).toBeFalsy();
+  });
+
+  it('Should display description if given', () => {
+    const description = 'Lorem ipsum dolor sit amet.';
+    const { container } = render({ description });
+    expect(container.querySelector('.description')).toHaveTextContent(
+      description,
+    );
+  });
+
+  it('Should not display error message by default', () => {
+    const { container } = render();
+    expect(container.querySelector('.error-message')).toBeFalsy();
+  });
+
+  it('Should display error message if given', () => {
+    const error = 'Something is wrong.';
+    const { container } = render({ error });
+    expect(container.querySelector('.error-message')).toHaveTextContent(error);
+  });
+
+  it('Should have class "field-set--small" by default', () => {
+    render();
+    expect(screen.getByRole('group')).toHaveClass('field-set--small');
+    expect(screen.getByRole('group')).not.toHaveClass('field-set--xsmall');
+  });
+
+  it('Should have class "field-set--small" if the "size" property is set to "small"', () => {
+    render({ size: FieldSetSize.Small });
+    expect(screen.getByRole('group')).toHaveClass('field-set--small');
+    expect(screen.getByRole('group')).not.toHaveClass('field-set--xsmall');
+  });
+
+  it('Should have class "field-set--xsmall" if the "size" property is set to "xsmall"', () => {
+    render({ size: FieldSetSize.Xsmall });
+    expect(screen.getByRole('group')).toHaveClass('field-set--xsmall');
+    expect(screen.getByRole('group')).not.toHaveClass('field-set--small');
+  });
+
+  it('Should be enabled by default', () => {
+    render();
+    expect(screen.getByRole('group')).toBeEnabled();
+  });
+
+  it('Should be disabled if the "disabled" property is true', () => {
+    render({ disabled: true });
+    expect(screen.getByRole('group')).toBeDisabled();
+  });
+
+  it('Should be enabled if the "disabled" property is false', () => {
+    render({ disabled: false });
+    expect(screen.getByRole('group')).toBeEnabled();
+  });
+});
+
+const render = (props: Partial<FieldSetProps> = {}) => {
+  const allProps = { ...defaultProps, ...props };
+  return renderRtl(<FieldSet {...allProps}>{allProps.children}</FieldSet>);
+};

--- a/src/components/FieldSet/FieldSet.test.tsx
+++ b/src/components/FieldSet/FieldSet.test.tsx
@@ -27,26 +27,28 @@ describe('FieldSet', () => {
 
   it('Should not display description by default', () => {
     const { container } = render();
-    expect(container.querySelector('.description')).toBeFalsy();
+    expect(container.querySelector('.field-set__description')).toBeFalsy();
   });
 
   it('Should display description if given', () => {
     const description = 'Lorem ipsum dolor sit amet.';
     const { container } = render({ description });
-    expect(container.querySelector('.description')).toHaveTextContent(
-      description,
-    );
+    expect(
+      container.querySelector('.field-set__description'),
+    ).toHaveTextContent(description);
   });
 
   it('Should not display error message by default', () => {
     const { container } = render();
-    expect(container.querySelector('.error-message')).toBeFalsy();
+    expect(container.querySelector('.field-set__error-message')).toBeFalsy();
   });
 
   it('Should display error message if given', () => {
     const error = 'Something is wrong.';
     const { container } = render({ error });
-    expect(container.querySelector('.error-message')).toHaveTextContent(error);
+    expect(
+      container.querySelector('.field-set__error-message'),
+    ).toHaveTextContent(error);
   });
 
   it('Should have class "field-set--small" by default', () => {

--- a/src/components/FieldSet/FieldSet.tsx
+++ b/src/components/FieldSet/FieldSet.tsx
@@ -38,11 +38,15 @@ export const FieldSet = ({
       )}
       disabled={disabled}
     >
-      {legend && <legend className={classes.legend}>{legend}</legend>}
-      {description && <p className={classes.description}>{description}</p>}
-      <div className={classes.content}>{children}</div>
+      {legend && (
+        <legend className={classes['field-set__legend']}>{legend}</legend>
+      )}
+      {description && (
+        <p className={classes['field-set__description']}>{description}</p>
+      )}
+      <div className={classes['field-set__content']}>{children}</div>
       {error && (
-        <div className={classes['error-message']}>
+        <div className={classes['field-set__error-message']}>
           <ErrorMessage>{error}</ErrorMessage>
         </div>
       )}

--- a/src/components/FieldSet/FieldSet.tsx
+++ b/src/components/FieldSet/FieldSet.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import cn from 'classnames';
+
+import { ErrorMessage } from '@/components';
+
+import classes from './FieldSet.module.css';
+
+export interface FieldSetProps {
+  children: React.ReactNode;
+  className?: string;
+  description?: string;
+  disabled?: boolean;
+  error?: React.ReactNode;
+  legend?: string;
+  size?: FieldSetSize;
+}
+
+export enum FieldSetSize {
+  Xsmall = 'xsmall',
+  Small = 'small',
+}
+
+export const FieldSet = ({
+  children,
+  className,
+  description,
+  disabled,
+  error,
+  legend,
+  size = FieldSetSize.Small,
+}: FieldSetProps) => {
+  return (
+    <fieldset
+      className={cn(
+        classes['field-set'],
+        classes[`field-set--${size}`],
+        className,
+      )}
+      disabled={disabled}
+    >
+      {legend && <legend className={classes.legend}>{legend}</legend>}
+      {description && <p className={classes.description}>{description}</p>}
+      <div className={classes.content}>{children}</div>
+      {error && (
+        <div className={classes['error-message']}>
+          <ErrorMessage>{error}</ErrorMessage>
+        </div>
+      )}
+    </fieldset>
+  );
+};

--- a/src/components/FieldSet/index.ts
+++ b/src/components/FieldSet/index.ts
@@ -1,0 +1,1 @@
+export { FieldSet } from './FieldSet';

--- a/src/components/FieldSet/index.ts
+++ b/src/components/FieldSet/index.ts
@@ -1,1 +1,1 @@
-export { FieldSet } from './FieldSet';
+export { FieldSet, FieldSetSize } from './FieldSet';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -21,4 +21,4 @@ export { Checkbox } from './Checkbox';
 export { TextArea } from './TextArea';
 export type { IconVariant, ReadOnlyVariant } from './_InputWrapper';
 export { CheckboxGroup } from './CheckboxGroup';
-export { FieldSet } from './FieldSet';
+export { FieldSet, FieldSetSize } from './FieldSet';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -21,3 +21,4 @@ export { Checkbox } from './Checkbox';
 export { TextArea } from './TextArea';
 export type { IconVariant, ReadOnlyVariant } from './_InputWrapper';
 export { CheckboxGroup } from './CheckboxGroup';
+export { FieldSet } from './FieldSet';


### PR DESCRIPTION
## Description
I have separated the `fieldset` component from the `CheckboxGroup`, so that it can be used other places, like in the future radio button group. It will also be useful in the data modelling part of Altinn Studio. Ideally there would be designated Figma tokens for this, but for now I have just reused the checkbox-related tokens that were used on the `CheckboxGroup`. At the moment checkboxes are the only thing it's used for anyways.

## Related Issue(s)
- #155

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
