### PR TITLE
Add table component with pagination and sorting

### DIFF
--- a/src/components/Pagination/Pagination.module.css
+++ b/src/components/Pagination/Pagination.module.css
@@ -1,0 +1,22 @@
+.pagination-icon {
+  fill: rgb(0, 0, 0);
+}
+
+.pagination-icon:not(:last-child) {
+  margin-right: 20px;
+}
+
+.pagination-icon:hover {
+  cursor: pointer;
+}
+
+.pagination-icon--disabled {
+  fill: rgba(0, 0, 0, 0.4);
+  cursor: default !important;
+}
+
+.pagination-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: right;
+}

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import type { ComponentStory, ComponentMeta } from '@storybook/react';
+import { config } from 'storybook-addon-designs';
+
+import { StoryPage } from '@sb/StoryPage';
+
+import { Pagination } from './Pagination';
+
+const figmaLink = ''; // TODO: Add figma link
+
+export default {
+  title: `Components/Pagination`,
+  component: Pagination,
+  parameters: {
+    design: config([
+      {
+        type: 'figma',
+        url: figmaLink,
+      },
+      {
+        type: 'link',
+        url: figmaLink,
+      },
+    ]),
+    docs: {
+      page: () => (
+        <StoryPage
+          description={`TODO: Add a description (supports markdown)`}
+        />
+      ),
+    },
+  },
+  args: {
+    //TODO: Add default args
+  },
+} as ComponentMeta<typeof Pagination>;
+
+const Template: ComponentStory<typeof Pagination> = (args) => {
+  const [rowsPerPage, setRowsPerPage] = useState(5);
+  const [page, setPage] = useState(0);
+
+  const handleChangeRowsPerPage = (
+    event: React.ChangeEvent<HTMLSelectElement>,
+  ) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  return (
+    <Pagination
+      {...args}
+      rowsPerPage={rowsPerPage}
+      currentPage={page}
+      setCurrentPage={setPage}
+      onRowsPerPageChange={handleChangeRowsPerPage}
+    />
+  );
+};
+
+export const Example = Template.bind({});
+Example.args = {
+  numberOfRows: 200,
+  rowsPerPageOptions: [5, 10, 15, 20],
+  rowsPerPageText: 'Rader per side',
+  pageDescriptionText: 'av',
+};
+Example.parameters = {
+  docs: {
+    description: {
+      story: '', // TODO: add story description, supports markdown
+    },
+  },
+};

--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { render as renderRtl, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import type { PaginationProps } from './Pagination';
+import { Pagination } from './Pagination';
+
+const user = userEvent.setup();
+
+const render = (props: Partial<PaginationProps> = {}) => {
+  renderRtl(
+    <Pagination
+      {...defaultProps}
+      {...props}
+    />,
+  );
+};
+
+const defaultProps: PaginationProps = {
+  numberOfRows: 20,
+  rowsPerPageOptions: [5, 10, 15, 20],
+  rowsPerPage: 5,
+  onRowsPerPageChange: jest.fn(),
+  currentPage: 1,
+  setCurrentPage: jest.fn(),
+  rowsPerPageText: 'Rader per side',
+  pageDescriptionText: 'av',
+};
+
+describe('Pagination', () => {
+  it('should call onRowsPerPageChange when option in select is clicked', async () => {
+    const onRowsPerPageChange = jest.fn();
+
+    render({ onRowsPerPageChange });
+
+    await user.selectOptions(
+      screen.getByRole('combobox'),
+      screen.getByRole('option', { name: '10' }),
+    );
+
+    expect(onRowsPerPageChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onRowsPerPageChange when option in select is clicked', async () => {
+    const onRowsPerPageChange = jest.fn();
+
+    render({ onRowsPerPageChange });
+
+    await user.selectOptions(
+      screen.getByRole('combobox'),
+      screen.getByRole('option', { name: '10' }),
+    );
+
+    expect(onRowsPerPageChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('setCurrentPage should be updated when firstPageIcon is clicked', async () => {
+    const setCurrentPage = jest.fn();
+
+    render({ setCurrentPage });
+
+    await user.click(screen.getByTestId('first-page-icon'));
+
+    expect(setCurrentPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('setCurrentPage should be updated when firstPageIcon is clicked using key press enter', async () => {
+    const setCurrentPage = jest.fn();
+
+    render({ setCurrentPage });
+
+    await user.type(screen.getByTestId('first-page-icon'), '{Space}');
+
+    expect(setCurrentPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('setCurrentPage should be updated when firstPageIcon is clicked using key press tab and enter', async () => {
+    const setCurrentPage = jest.fn();
+
+    render({ setCurrentPage });
+
+    await user.keyboard('{Tab}');
+    await user.keyboard('{Tab}');
+    await user.keyboard('{Enter}');
+
+    expect(setCurrentPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('Description text should be rendered correctly', () => {
+    const pageDescriptionText = 'av';
+    const currentPage = 2;
+    const rowsPerPage = 5;
+    const numberOfRows = 100;
+
+    render({
+      rowsPerPage,
+      pageDescriptionText,
+      currentPage,
+      numberOfRows,
+    });
+
+    const text = screen.getByTestId('description-text');
+
+    expect(text).toHaveTextContent('11-15 av 100');
+  });
+});

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,0 +1,139 @@
+import React, { useEffect, useState } from 'react';
+import cn from 'classnames';
+
+import classes from './Pagination.module.css';
+import { ReactComponent as NavigateNextIcon } from './navigate_next.svg';
+import { ReactComponent as NavigateBeforeIcon } from './navigate_before.svg';
+import { ReactComponent as FirstPageIcon } from './first_page.svg';
+import { ReactComponent as LastPageIcon } from './last_page.svg';
+
+export interface PaginationProps {
+  numberOfRows: number;
+  rowsPerPageOptions: number[];
+  rowsPerPage: number;
+  onRowsPerPageChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
+  currentPage: number;
+  setCurrentPage: React.Dispatch<React.SetStateAction<number>>;
+  rowsPerPageText: string;
+  pageDescriptionText: string;
+}
+
+export const Pagination = ({
+  numberOfRows,
+  rowsPerPageOptions,
+  rowsPerPage,
+  onRowsPerPageChange,
+  currentPage,
+  setCurrentPage,
+  rowsPerPageText,
+  pageDescriptionText,
+}: PaginationProps) => {
+  const [numberOfPages, setNumberOfPages] = useState(1);
+
+  useEffect(() => {
+    if (numberOfRows < rowsPerPage) setNumberOfPages(1);
+    else setNumberOfPages(Math.ceil(numberOfRows / rowsPerPage));
+  }, [rowsPerPage, numberOfRows]);
+
+  const increaseCurrentPage = () => {
+    if (currentPage < numberOfPages - 1) {
+      setCurrentPage(currentPage + 1);
+    }
+  };
+
+  const decreaseCurrentPage = () => {
+    if (currentPage > 0) {
+      setCurrentPage(currentPage - 1);
+    }
+  };
+
+  const renderPaginationNumbers = () => {
+    const firstRowNumber = 1 + currentPage * rowsPerPage;
+    const lastRowNumber =
+      rowsPerPage * (currentPage + 1) > numberOfRows
+        ? numberOfRows
+        : rowsPerPage * (currentPage + 1);
+    return (
+      <p
+        style={{ marginRight: '64px', marginBottom: '0px' }}
+        data-testid='description-text'
+      >
+        {`${firstRowNumber}-${lastRowNumber} ${pageDescriptionText} ${numberOfRows}`}
+      </p>
+    );
+  };
+
+  return (
+    <div className={cn(classes['pagination-wrapper'])}>
+      <p style={{ marginRight: '26px', marginBottom: '0px' }}>
+        {rowsPerPageText}
+      </p>
+      <select
+        style={{ marginRight: '25px' }}
+        value={rowsPerPage}
+        onChange={(event) => onRowsPerPageChange(event)}
+      >
+        {rowsPerPageOptions.map((optionValue: number) => (
+          <option
+            key={optionValue}
+            value={optionValue}
+          >
+            {optionValue}
+          </option>
+        ))}
+      </select>
+      {renderPaginationNumbers()}
+      <FirstPageIcon
+        tabIndex={currentPage !== 0 ? 0 : undefined}
+        className={cn(classes['pagination-icon'], {
+          [classes['pagination-icon--disabled']]: currentPage === 0,
+        })}
+        onClick={() => setCurrentPage(0)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            setCurrentPage(0);
+          }
+        }}
+        data-testid='first-page-icon'
+      />
+      <NavigateBeforeIcon
+        tabIndex={currentPage !== 0 ? 0 : undefined}
+        className={cn(classes['pagination-icon'], {
+          [classes['pagination-icon--disabled']]: currentPage === 0,
+        })}
+        onClick={() => decreaseCurrentPage()}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            decreaseCurrentPage();
+          }
+        }}
+      />
+      <NavigateNextIcon
+        tabIndex={currentPage !== numberOfPages - 1 ? 0 : undefined}
+        className={cn(classes['pagination-icon'], {
+          [classes['pagination-icon--disabled']]:
+            currentPage === numberOfPages - 1,
+        })}
+        onClick={() => increaseCurrentPage()}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            increaseCurrentPage();
+          }
+        }}
+      />
+      <LastPageIcon
+        tabIndex={currentPage !== numberOfPages - 1 ? 0 : undefined}
+        className={cn(classes['pagination-icon'], {
+          [classes['pagination-icon--disabled']]:
+            currentPage === numberOfPages - 1,
+        })}
+        onClick={() => setCurrentPage(numberOfPages - 1)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            setCurrentPage(numberOfPages - 1);
+          }
+        }}
+      />
+    </div>
+  );
+};

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -31,8 +31,11 @@ export const Pagination = ({
   const [numberOfPages, setNumberOfPages] = useState(1);
 
   useEffect(() => {
-    if (numberOfRows < rowsPerPage) setNumberOfPages(1);
-    else setNumberOfPages(Math.ceil(numberOfRows / rowsPerPage));
+    if (numberOfRows < rowsPerPage) {
+      setNumberOfPages(1);
+    } else {
+      setNumberOfPages(Math.ceil(numberOfRows / rowsPerPage));
+    }
   }, [rowsPerPage, numberOfRows]);
 
   const increaseCurrentPage = () => {
@@ -54,20 +57,18 @@ export const Pagination = ({
         ? numberOfRows
         : rowsPerPage * (currentPage + 1);
     return (
-      <p
-        style={{ marginRight: '64px', marginBottom: '0px' }}
+      <span
+        style={{ marginRight: '64px' }}
         data-testid='description-text'
       >
         {`${firstRowNumber}-${lastRowNumber} ${pageDescriptionText} ${numberOfRows}`}
-      </p>
+      </span>
     );
   };
 
   return (
     <div className={cn(classes['pagination-wrapper'])}>
-      <p style={{ marginRight: '26px', marginBottom: '0px' }}>
-        {rowsPerPageText}
-      </p>
+      <span style={{ marginRight: '26px' }}>{rowsPerPageText}</span>
       <select
         style={{ marginRight: '25px' }}
         value={rowsPerPage}
@@ -89,7 +90,7 @@ export const Pagination = ({
           [classes['pagination-icon--disabled']]: currentPage === 0,
         })}
         onClick={() => setCurrentPage(0)}
-        onKeyDown={(event) => {
+        onKeyUp={(event) => {
           if (event.key === 'Enter' || event.key === ' ') {
             setCurrentPage(0);
           }
@@ -102,7 +103,7 @@ export const Pagination = ({
           [classes['pagination-icon--disabled']]: currentPage === 0,
         })}
         onClick={() => decreaseCurrentPage()}
-        onKeyDown={(event) => {
+        onKeyUp={(event) => {
           if (event.key === 'Enter' || event.key === ' ') {
             decreaseCurrentPage();
           }
@@ -115,7 +116,7 @@ export const Pagination = ({
             currentPage === numberOfPages - 1,
         })}
         onClick={() => increaseCurrentPage()}
-        onKeyDown={(event) => {
+        onKeyUp={(event) => {
           if (event.key === 'Enter' || event.key === ' ') {
             increaseCurrentPage();
           }
@@ -128,7 +129,7 @@ export const Pagination = ({
             currentPage === numberOfPages - 1,
         })}
         onClick={() => setCurrentPage(numberOfPages - 1)}
-        onKeyDown={(event) => {
+        onKeyUp={(event) => {
           if (event.key === 'Enter' || event.key === ' ') {
             setCurrentPage(numberOfPages - 1);
           }

--- a/src/components/Pagination/first_page.svg
+++ b/src/components/Pagination/first_page.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M18.41 16.59L13.82 12l4.59-4.59L17 6l-6 6 6 6zM6 6h2v12H6z"/></svg>

--- a/src/components/Pagination/index.ts
+++ b/src/components/Pagination/index.ts
@@ -1,0 +1,1 @@
+export { Pagination } from './Pagination';

--- a/src/components/Pagination/last_page.svg
+++ b/src/components/Pagination/last_page.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M5.59 7.41L10.18 12l-4.59 4.59L7 18l6-6-6-6zM16 6h2v12h-2z"/></svg>

--- a/src/components/Pagination/navigate_before.svg
+++ b/src/components/Pagination/navigate_before.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg>

--- a/src/components/Pagination/navigate_next.svg
+++ b/src/components/Pagination/navigate_next.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>

--- a/src/components/Table/Context.ts
+++ b/src/components/Table/Context.ts
@@ -1,0 +1,64 @@
+import { createContext, useContext } from 'react';
+
+import type { SortDirection } from './TableCell';
+
+export enum Variant {
+  Header = 'header',
+  Body = 'body',
+  Footer = 'footer',
+}
+
+export interface ChangeProps {
+  selectedValue: string;
+}
+export interface SortProps {
+  idCell: number;
+  previousSortDirection: SortDirection;
+}
+
+export type ChangeHandler = ({ selectedValue }: ChangeProps) => void;
+export type SortHandler = ({
+  idCell,
+  previousSortDirection,
+}: SortProps) => void;
+
+export const TableContext = createContext<
+  | {
+      selectRows?: boolean;
+      selectedValue?: string;
+      onChange?: ChangeHandler;
+    }
+  | undefined
+>(undefined);
+export const useTableContext = () => {
+  const context = useContext(TableContext);
+  if (context === undefined) {
+    throw new Error('useTableContext must be used within a TableContext');
+  }
+  return context;
+};
+
+export const SortContext = createContext<
+  | {
+      selectSort?: string;
+    }
+  | undefined
+>(undefined);
+export const useSortContext = () => {
+  const context = useContext(SortContext);
+  if (context === undefined) {
+    throw new Error('useTableContext must be used within a TableContext');
+  }
+  return context;
+};
+
+export const TableRowTypeContext = createContext({
+  variantStandard: Variant.Body,
+});
+export const useTableRowTypeContext = () => {
+  const context = useContext(TableRowTypeContext);
+  if (context === undefined) {
+    throw new Error('useTableContext must be used within a TableTypeContext');
+  }
+  return context;
+};

--- a/src/components/Table/Table.module.css
+++ b/src/components/Table/Table.module.css
@@ -1,0 +1,13 @@
+Table {
+  /* #FFFFFF */
+
+  /* Inside auto layout */
+  background-color: #ffffff;
+  flex: none;
+  order: 3;
+  align-self: stretch;
+  flex-grow: 0;
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: 100%;
+}

--- a/src/components/Table/Table.stories.module.css
+++ b/src/components/Table/Table.stories.module.css
@@ -1,0 +1,4 @@
+img {
+  max-width: 45px;
+  max-height: 45px;
+}

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -1,0 +1,257 @@
+import React, { useState } from 'react';
+import type { ComponentStory, ComponentMeta } from '@storybook/react';
+import { config } from 'storybook-addon-designs';
+import cn from 'classnames';
+
+import { StoryPage } from '@sb/StoryPage';
+
+import { Pagination } from '../Pagination';
+
+import { Table } from './Table';
+import { TableHeader } from './TableHeader';
+import { SortDirection, TableCell } from './TableCell';
+import { TableRow } from './TableRow';
+import { TableBody } from './TableBody';
+import type { ChangeProps, SortProps } from './Context';
+import classes from './Table.stories.module.css';
+import { TableFooter } from './TableFooter';
+const figmaLink = ''; // TODO: Add figma link
+
+export default {
+  title: `Components/Table`,
+  component: Table,
+  parameters: {
+    design: config([
+      {
+        type: 'figma',
+        url: figmaLink,
+      },
+      {
+        type: 'link',
+        url: figmaLink,
+      },
+    ]),
+    docs: {
+      page: () => (
+        <StoryPage
+          description={`TODO: Add a description (supports markdown)`}
+        />
+      ),
+    },
+  },
+  args: {
+    //TODO: Add default args
+  },
+} as ComponentMeta<typeof Table>;
+
+function createData(
+  applicationNr: string,
+  product: string,
+  status: string,
+  imageSrc: string,
+  imageAlt: string,
+) {
+  return {
+    applicationNr,
+    product,
+    status,
+    imageSrc,
+    imageAlt,
+  };
+}
+
+const rows = [
+  createData(
+    '20220873',
+    'Embalasje for snacksprodukter',
+    'Under behandling',
+    'https://search.patentstyret.no/onlinedb_files_ds/Pictures/2022/9/21/317574.png',
+    'chipspose',
+  ),
+  createData(
+    '20220590',
+    'Apparat for rengjøring av sveisesøm',
+    'Registert',
+    'https://search.patentstyret.no/onlinedb_files_ds/Pictures/2022/6/30/313443.jpg',
+    'apparat for rengjøring av sveisesøm',
+  ),
+  createData(
+    '20220827',
+    'Logo',
+    'Besluttet gjeldene',
+    'https://search.patentstyret.no/onlinedb_files_ds/Pictures/2022/9/17/317418.JPG',
+    'logo',
+  ),
+  createData(
+    '20220582',
+    'Modul for handikaprampe, Bunnramme til modul for handikaprampe, Rekkverk til modul for handikaprampe',
+    'Registrert',
+    'https://search.patentstyret.no/onlinedb_files_ds/Pictures/2022/6/20/313066.jpg',
+    'bilde av handikaprampe',
+  ),
+  createData(
+    '20220408',
+    'Bil',
+    'Registert',
+    'https://search.patentstyret.no/onlinedb_files_ds/Pictures/2022/5/11/310547.jpg',
+    'Bil',
+  ),
+  createData(
+    '200208507',
+    'Vippesykkel',
+    'Besluttet gjeldende',
+    'https://search.patentstyret.no/Onlinedb_files_tm/Pictures/200208/200208507.jpg',
+    'vippesykkel',
+  ),
+  createData(
+    '200812696',
+    'SHELL',
+    'Besluttet gjeldende',
+    'https://search.patentstyret.no/Onlinedb_files_tm/Pictures/200431/200812696.jpg',
+    'shell',
+  ),
+  createData(
+    '201106591',
+    'DNB',
+    'Registrert',
+    'https://search.patentstyret.no/Onlinedb_files_tm/Pictures/200448/201106591_5%20Figurmerker%20og%20bilder(cropped)%20-%201_200523766_0.jpg',
+    'dnb',
+  ),
+];
+
+const Template: ComponentStory<typeof Table> = (args) => {
+  const [selected, setSelected] = useState('');
+  const [selectedSort, setSelectedSort] = useState({
+    idCell: 0,
+    sortDirection: SortDirection.NotActive,
+  });
+  const [rowsPerPage, setRowsPerPage] = useState(5);
+  const [page, setPage] = useState(0);
+
+  const handleChange = ({ selectedValue }: ChangeProps) => {
+    setSelected(selectedValue);
+  };
+  const handleSortChange = ({ idCell, previousSortDirection }: SortProps) => {
+    if (previousSortDirection === SortDirection.Ascending) {
+      setSelectedSort({
+        idCell: idCell,
+        sortDirection: SortDirection.Descending,
+      });
+    } else if (previousSortDirection === SortDirection.Descending) {
+      setSelectedSort({
+        idCell: idCell,
+        sortDirection: SortDirection.Ascending,
+      });
+    } else {
+      setSelectedSort({
+        idCell: idCell,
+        sortDirection: SortDirection.Ascending,
+      });
+    }
+  };
+
+  const handleChangeRowsPerPage = (
+    event: React.ChangeEvent<HTMLSelectElement>,
+  ) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  return (
+    <Table
+      selectRows={args.selectRows}
+      onChange={handleChange}
+      selectedValue={selected}
+    >
+      <TableHeader>
+        <TableRow>
+          <TableCell
+            onChange={handleSortChange}
+            id={1}
+            sortDirecton={
+              selectedSort.idCell === 1
+                ? selectedSort.sortDirection
+                : SortDirection.NotActive
+            }
+          >
+            Søknadsnr.
+          </TableCell>
+          <TableCell
+            id={2}
+            onChange={handleSortChange}
+            sortDirecton={
+              selectedSort.idCell === 2
+                ? selectedSort.sortDirection
+                : SortDirection.NotActive
+            }
+          >
+            Produkt
+          </TableCell>
+          <TableCell>Status</TableCell>
+          <TableCell>Bilde</TableCell>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows
+          .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+          .map((row) => (
+            <TableRow
+              key={row.applicationNr}
+              value={row.applicationNr}
+            >
+              <TableCell>{row.applicationNr}</TableCell>
+              <TableCell>{row.product}</TableCell>
+              <TableCell>{row.status}</TableCell>
+              <TableCell>
+                <img
+                  className={cn(classes['checkmark'])}
+                  src={row.imageSrc}
+                  alt={row.imageAlt}
+                ></img>
+              </TableCell>
+            </TableRow>
+          ))}
+      </TableBody>
+      <TableFooter>
+        <TableRow>
+          <TableCell colSpan={4}>
+            <Pagination
+              numberOfRows={rows.length}
+              rowsPerPageOptions={[5, 10, 15, 20]}
+              rowsPerPage={rowsPerPage}
+              onRowsPerPageChange={handleChangeRowsPerPage}
+              currentPage={page}
+              setCurrentPage={setPage}
+              rowsPerPageText='Rader per side'
+              pageDescriptionText='av'
+            />
+          </TableCell>
+        </TableRow>
+      </TableFooter>
+    </Table>
+  );
+};
+
+export const BasicTable = Template.bind({});
+BasicTable.args = {
+  selectRows: false,
+};
+BasicTable.parameters = {
+  docs: {
+    description: {
+      story: '', // TODO: add story description, supports markdown
+    },
+  },
+};
+
+export const SelectRows = Template.bind({});
+SelectRows.args = {
+  selectRows: true,
+};
+SelectRows.parameters = {
+  docs: {
+    description: {
+      story: '', // TODO: add story description, supports markdown
+    },
+  },
+};

--- a/src/components/Table/Table.test.tsx
+++ b/src/components/Table/Table.test.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { render as renderRtl, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import type { TableProps } from './Table';
+import { Table } from './Table';
+import { TableBody } from './TableBody';
+import { TableCell } from './TableCell';
+import { TableHeader } from './TableHeader';
+import { TableRow } from './TableRow';
+
+const render = (props: Partial<TableProps> = {}) => {
+  const allProps = {
+    children: (
+      <>
+        <TableHeader>
+          <TableRow>
+            <TableCell>Frukt</TableCell>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow value='apple'>
+            <TableCell>Apple</TableCell>
+          </TableRow>
+          <TableRow value='orange'>
+            <TableCell>Orange</TableCell>
+          </TableRow>
+        </TableBody>
+      </>
+    ),
+    onChange: jest.fn(),
+    selectRows: true,
+    selectedValue: '',
+    ...props,
+  };
+  renderRtl(<Table {...allProps} />);
+};
+
+const user = userEvent.setup();
+
+describe('Table', () => {
+  it('should call handleChange with correct selectedValue when TableRow is clicked and selectRows is true', async () => {
+    const handleChange = jest.fn();
+    render({ onChange: handleChange, selectRows: true });
+
+    await user.click(screen.getByRole('row', { name: 'Apple' }));
+    expect(handleChange).toHaveBeenCalledWith({ selectedValue: 'apple' });
+  });
+});
+
+describe('Table', () => {
+  it('should call handleChange with correct selectedValue when one row is clicked by enter and selectRows is true', async () => {
+    const handleChange = jest.fn();
+    render({ onChange: handleChange, selectRows: true });
+
+    await user.keyboard('{Tab}');
+    await user.keyboard('{Enter}');
+    expect(handleChange).toHaveBeenCalledWith({ selectedValue: 'apple' });
+  });
+});
+
+describe('Table', () => {
+  it('should call handleChange when TableRow is clicked using key press Space and selectRows is true', async () => {
+    const handleChange = jest.fn();
+    render({ onChange: handleChange, selectRows: true });
+
+    const Row = screen.getByRole('row', {
+      name: 'Apple',
+    });
+    await user.type(Row, '{Space}');
+    expect(handleChange).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Table', () => {
+  it('should not call handleChange when when selectRows is false and TableRow is clicked', async () => {
+    const handleChange = jest.fn();
+    render({ onChange: handleChange, selectRows: false });
+
+    await user.click(screen.getByRole('row', { name: 'Apple' }));
+    expect(handleChange).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe('Table', () => {
+  it('should not call handleChange when when selectRows is false and TableRow is clicked by enter', async () => {
+    const handleChange = jest.fn();
+    render({ onChange: handleChange, selectRows: false });
+
+    await user.keyboard('{Tab}');
+    await user.keyboard('{Enter}');
+    expect(handleChange).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe('Table', () => {
+  it('should not call handleChange when selectRows is false and TableRow is clicked using key press Space', async () => {
+    const handleChange = jest.fn();
+    render({ onChange: handleChange, selectRows: false });
+
+    const Row = screen.getByRole('row', {
+      name: 'Apple',
+    });
+    await user.type(Row, '{Space}');
+    expect(handleChange).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import cn from 'classnames';
+
+import classes from './Table.module.css';
+import type { ChangeHandler } from './Context';
+import { TableContext } from './Context';
+
+export interface TableProps {
+  children?: React.ReactNode;
+  selectRows?: boolean;
+  onChange?: ChangeHandler;
+  selectedValue?: string;
+}
+
+export const Table = ({
+  children,
+  selectRows = false,
+  onChange,
+  selectedValue,
+}: TableProps) => {
+  return (
+    <table className={cn(classes.Table)}>
+      <TableContext.Provider value={{ selectRows, onChange, selectedValue }}>
+        {children}
+      </TableContext.Provider>
+    </table>
+  );
+};
+
+export default Table;

--- a/src/components/Table/TableBody.module.css
+++ b/src/components/Table/TableBody.module.css
@@ -1,0 +1,9 @@
+.TableBody {
+  /* Inside auto layout */
+
+  flex: none;
+  order: 2;
+  align-self: stretch;
+  flex-grow: 0;
+  background-color: #ffff;
+}

--- a/src/components/Table/TableBody.tsx
+++ b/src/components/Table/TableBody.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import cn from 'classnames';
+
+import classes from './TableBody.module.css';
+import { Variant, TableRowTypeContext } from './Context';
+
+export interface TableBodyProps {
+  children?: React.ReactNode;
+}
+
+export const TableBody = ({ children }: TableBodyProps) => {
+  const variantStandard = Variant.Body;
+  return (
+    <TableRowTypeContext.Provider value={{ variantStandard }}>
+      <tbody className={cn(classes.TableBody)}>{children}</tbody>
+    </TableRowTypeContext.Provider>
+  );
+};
+
+export default TableBody;

--- a/src/components/Table/TableCell.module.css
+++ b/src/components/Table/TableCell.module.css
@@ -1,0 +1,51 @@
+.header-table-cell {
+  text-align: left;
+  padding: 8px;
+  margin: 20px 0 20px 0;
+  background: #f5f5f5;
+  user-select: none;
+}
+
+.body-table-cell {
+  text-align: left;
+  padding: 8px;
+  border-top: 1px solid #dde3e5;
+  max-width: 300px;
+  margin: 20px 0 20px 0;
+  min-width: 100px;
+  border-top: 1px solid #dde3e5;
+  border-bottom: 1px solid #dde3e5;
+}
+
+.image {
+  max-width: 45px;
+  max-height: 45px;
+}
+
+.input {
+  margin: 0px 15px 0px 15px;
+}
+
+.container-sortable {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+  cursor: pointer;
+}
+
+.icon {
+  fill: rgba(0, 0, 0, 0.4);
+  margin-left: -5px;
+}
+
+.icon-asc {
+  fill: rgb(0, 0, 0);
+  margin-left: -5px;
+}
+
+.icon-desc {
+  fill: rgb(0, 0, 0);
+  transform: rotate(180deg);
+  margin-left: -5px;
+}

--- a/src/components/Table/TableCell.tsx
+++ b/src/components/Table/TableCell.tsx
@@ -59,7 +59,11 @@ export const TableCell = ({
                 : cn(classes['container'])
             }
             onClick={() => handleChange()}
-            onKeyUp={() => handleChange()}
+            onKeyUp={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                handleChange();
+              }
+            }}
             role={
               sortDirecton != SortDirection.NotSortable ? 'button' : undefined
             }

--- a/src/components/Table/TableCell.tsx
+++ b/src/components/Table/TableCell.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import cn from 'classnames';
+
+import classes from './TableCell.module.css';
+import type { SortHandler } from './Context';
+import { useTableRowTypeContext, Variant } from './Context';
+import { ReactComponent as SortIcon } from './sort_arrow.svg';
+
+export interface TableCellProps {
+  children?: React.ReactNode;
+  variant?: string;
+  colSpan?: number;
+  type?: string;
+  src?: string;
+  alt?: string;
+  sortable?: boolean;
+  onChange?: SortHandler;
+  sortDirecton?: SortDirection;
+  id?: number;
+}
+export enum SortDirection {
+  Descending = 'desc',
+  Ascending = 'asc',
+  NotSortable = 'notSortable',
+  NotActive = 'notActive',
+}
+
+export const TableCell = ({
+  children,
+  colSpan = 1,
+  variant,
+  onChange,
+  sortDirecton = SortDirection.NotSortable,
+  id,
+}: TableCellProps) => {
+  const { variantStandard } = useTableRowTypeContext();
+
+  const handleChange = () => {
+    if (onChange != undefined && id != undefined && sortDirecton != undefined) {
+      onChange({
+        idCell: id,
+        previousSortDirection: sortDirecton,
+      });
+    }
+  };
+  return (
+    <>
+      {(variant == undefined
+        ? variantStandard === Variant.Header
+        : variant === 'header') && (
+        <th
+          className={cn(classes['header-table-cell'])}
+          colSpan={colSpan}
+        >
+          <div
+            className={
+              sortDirecton != SortDirection.NotSortable
+                ? cn(classes['container-sortable'])
+                : cn(classes['container'])
+            }
+            onClick={() => handleChange()}
+            onKeyUp={() => handleChange()}
+            role={
+              sortDirecton != SortDirection.NotSortable ? 'button' : undefined
+            }
+            tabIndex={sortDirecton != SortDirection.NotSortable ? 0 : undefined}
+          >
+            <div className={cn(classes['input'])}>{children}</div>
+            {sortDirecton != SortDirection.NotSortable && (
+              <SortIcon
+                className={cn(classes['icon'], {
+                  [classes['icon-asc']]:
+                    sortDirecton === SortDirection.Ascending,
+                  [classes['icon-desc']]:
+                    sortDirecton === SortDirection.Descending,
+                })}
+              ></SortIcon>
+            )}
+          </div>
+        </th>
+      )}
+      {(variant == undefined
+        ? variantStandard === Variant.Body
+        : variant === 'body') && (
+        <>
+          <td
+            className={cn(classes['body-table-cell'])}
+            colSpan={colSpan}
+          >
+            <div className={cn(classes['input'])}>{children}</div>
+          </td>
+        </>
+      )}
+      {variantStandard === Variant.Footer && (
+        <td colSpan={colSpan}>
+          <div className={cn(classes['input'])}>{children}</div>
+        </td>
+      )}
+    </>
+  );
+};
+
+export default TableCell;

--- a/src/components/Table/TableFooter.module.css
+++ b/src/components/Table/TableFooter.module.css
@@ -1,0 +1,7 @@
+.table-footer {
+  background: #f5f5f5;
+  flex: none;
+  order: 1;
+  align-self: stretch;
+  flex-grow: 0;
+}

--- a/src/components/Table/TableFooter.tsx
+++ b/src/components/Table/TableFooter.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import cn from 'classnames';
+
+import classes from './TableFooter.module.css';
+import { Variant, TableRowTypeContext } from './Context';
+
+export interface TableFooterProps {
+  children?: React.ReactNode;
+}
+
+export const TableFooter = ({ children }: TableFooterProps) => {
+  const variantStandard = Variant.Footer;
+  return (
+    <TableRowTypeContext.Provider value={{ variantStandard }}>
+      <tfoot className={cn(classes['table-footer'])}>{children}</tfoot>
+    </TableRowTypeContext.Provider>
+  );
+};
+
+export default TableFooter;

--- a/src/components/Table/TableHeader.module.css
+++ b/src/components/Table/TableHeader.module.css
@@ -1,0 +1,7 @@
+.table-header {
+  background: #f5f5f5;
+  flex: none;
+  order: 1;
+  align-self: stretch;
+  flex-grow: 0;
+}

--- a/src/components/Table/TableHeader.tsx
+++ b/src/components/Table/TableHeader.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import cn from 'classnames';
+
+import classes from './TableHeader.module.css';
+import { Variant, TableRowTypeContext } from './Context';
+
+export interface TableHeaderProps {
+  children?: React.ReactNode;
+}
+
+export const TableHeader = ({ children }: TableHeaderProps) => {
+  const variantStandard = Variant.Header;
+  return (
+    <TableRowTypeContext.Provider value={{ variantStandard }}>
+      <thead className={cn(classes['table-header'])}>{children}</thead>
+    </TableRowTypeContext.Provider>
+  );
+};

--- a/src/components/Table/TableRow.module.css
+++ b/src/components/Table/TableRow.module.css
@@ -1,0 +1,16 @@
+.TableRow {
+  width: 1056px;
+  height: 60px;
+}
+
+.table-row--selected {
+  background-color: #e0daf7;
+  border-top: 1px solid #dde3e5;
+  border-bottom: 1px solid #dde3e5;
+  border-left: 2px solid #011728;
+}
+
+.table-row--body:hover {
+  background-color: #e3f7ff;
+  cursor: pointer;
+}

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import cn from 'classnames';
+
+import classes from './TableRow.module.css';
+import {
+  SortContext,
+  useTableContext,
+  useTableRowTypeContext,
+  Variant,
+} from './Context';
+
+export interface TableRowProps {
+  children?: React.ReactNode;
+  value?: string;
+  selectSort?: string;
+}
+
+export const TableRow = ({
+  children,
+  value = 'no',
+  selectSort = '',
+}: TableRowProps) => {
+  const { variantStandard } = useTableRowTypeContext();
+  const { onChange, selectedValue, selectRows } = useTableContext();
+  const handleClick = () => {
+    if (
+      onChange != undefined &&
+      selectRows &&
+      variantStandard === Variant.Body
+    ) {
+      onChange({ selectedValue: value });
+    }
+  };
+
+  const handleEnter = (event: React.KeyboardEvent<HTMLTableRowElement>) => {
+    if ((event.key === 'Enter' || event.key === ' ') && onChange != undefined) {
+      onChange({ selectedValue: value });
+    }
+  };
+
+  return (
+    <SortContext.Provider value={{ selectSort }}>
+      <tr
+        className={cn(classes.TableRow, {
+          [classes['table-row--selected']]: value === selectedValue,
+          [classes['table-row--body']]:
+            variantStandard === Variant.Body &&
+            selectRows &&
+            value !== selectedValue,
+        })}
+        onClick={handleClick}
+        tabIndex={
+          variantStandard === Variant.Body && selectRows ? 0 : undefined
+        }
+        onKeyDown={(event) => handleEnter(event)}
+      >
+        {children}
+      </tr>
+    </SortContext.Provider>
+  );
+};
+
+export default TableRow;

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -52,7 +52,7 @@ export const TableRow = ({
         tabIndex={
           variantStandard === Variant.Body && selectRows ? 0 : undefined
         }
-        onKeyDown={(event) => handleEnter(event)}
+        onKeyUp={(event) => handleEnter(event)}
       >
         {children}
       </tr>

--- a/src/components/Table/index.ts
+++ b/src/components/Table/index.ts
@@ -1,0 +1,7 @@
+export { Table } from './Table';
+export { TableHeader } from './TableHeader';
+export { TableRow } from './TableRow';
+export { TableBody } from './TableBody';
+export { TableCell } from './TableCell';
+export { TableFooter } from './TableFooter';
+export type { ChangeProps } from './Context';

--- a/src/components/Table/sort_arrow.svg
+++ b/src/components/Table/sort_arrow.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="5" viewBox="0 0 10 5" xmlns="http://www.w3.org/2000/svg">
+<path d="M9.30758 0.229492H1.12508H0.333221L4.8204 4.89616L9.30758 0.229492Z" fill="black"/>
+</svg>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -17,8 +17,18 @@ export { SearchField } from './SearchField';
 export { ErrorMessage } from './ErrorMessage';
 export type { Location, MapLayer } from './Map';
 export { Map } from './Map';
+export type { ChangeProps } from './Table';
+export {
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableRow,
+  TableFooter,
+} from './Table';
 export { Checkbox } from './Checkbox';
 export { TextArea } from './TextArea';
 export type { IconVariant, ReadOnlyVariant } from './_InputWrapper';
 export { CheckboxGroup } from './CheckboxGroup';
 export { FieldSet, FieldSetSize } from './FieldSet';
+export { Pagination } from './Pagination';


### PR DESCRIPTION
## Description
We have added two new components: Table and Pagination. 

Table consists of several parts: Table, TableHeader, TableBody, TableFooter, TableRow and TableCell. Some features: 
- A tablecell will automatically adjust to its wrapper (footer, header, body), but can be overruled by a prop. 
- The table component takes a prop stating if the rows should be selectable. 
- A table header cell/column can be sortable by a prop. 

Pagination component is a simple pagination component. It takes props for dynamic text and to make it possible to connect a table and pagination. 

The table story shows both table and pagination working togheter. 

## Related Issue(s)
- #

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
