### PR TITLE
Invisible label on checkbox

### DIFF
--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -128,3 +128,14 @@ LongText.parameters = {
     },
   },
 };
+
+export const WithHiddenLabel = Template.bind({});
+WithHiddenLabel.args = { hideLabel: true };
+WithHiddenLabel.parameters = {
+  docs: {
+    description: {
+      story:
+        "This is a checkbox with the `hiddenLabel` property enabled. Use this in table views and other places where there is no need to have a specific, visible label for the checkbox. If the `label` property is set in this case, it will be made available for accessibility tools through the HTML component's `aria-label` attribute.",
+    },
+  },
+};

--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -52,6 +52,13 @@ describe('Checkbox', () => {
     expect(screen.getByText(label)).toBeDefined();
   });
 
+  it('Should not display label text, but still make it accessible, when hideLabel is true', () => {
+    const label = 'Lorem ipsum';
+    render({ hideLabel: true, label });
+    expect(screen.queryByText(label)).toBeFalsy();
+    expect(screen.getByLabelText(label)).toBeTruthy();
+  });
+
   it('Should render checkbox with given checkboxId', () => {
     const checkboxId = 'the-checkbox';
     render({ checkboxId });

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -11,6 +11,7 @@ export interface CheckboxProps {
   description?: string;
   disabled?: boolean;
   error?: boolean;
+  hideLabel?: boolean;
   label?: string;
   name?: string;
   onChange: ChangeEventHandler<HTMLInputElement>;
@@ -24,6 +25,7 @@ export const Checkbox = ({
   description,
   disabled,
   error,
+  hideLabel,
   label,
   name,
   onChange,
@@ -33,6 +35,7 @@ export const Checkbox = ({
   const inputId = checkboxId || 'checkbox-' + randomId;
   const labelId = label ? `${inputId}-label` : undefined;
   const descriptionId = description ? `${inputId}-description` : undefined;
+  const showLabel = label && !hideLabel;
 
   return (
     <label
@@ -50,7 +53,8 @@ export const Checkbox = ({
         <span className={classes['checkbox-wrapper']}>
           <input
             aria-describedby={descriptionId}
-            aria-labelledby={labelId}
+            aria-label={!showLabel ? label : undefined}
+            aria-labelledby={showLabel ? labelId : undefined}
             checked={checked ?? false}
             className={classes.checkbox}
             disabled={disabled}
@@ -64,9 +68,9 @@ export const Checkbox = ({
           </span>
         </span>
       )}
-      {(label || description) && (
+      {(showLabel || description) && (
         <span className={classes['label-and-description']}>
-          {label && (
+          {showLabel && (
             <span
               className={classes.label}
               id={`${inputId}-label`}


### PR DESCRIPTION
## Description
If the checkbox is not supposed to have a visible label, it should still have an `aria-label` on the HTML attribute. I have therefore added a `hideLabel` property that hides the label and adds it to the `aria-label` property instead.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
