### PR TITLE
add inverted color dashed border full width option

### DIFF
--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -1,9 +1,11 @@
 .button {
   --icon-size: var(--component-button-size-icon-small);
+  --button-vertical-padding: var(--component-button-space-padding-x-small);
 
   all: initial; /* reset all styles to default, to avoid style overrides/surprises caused by other css (from Design system v1 f.ex) */
   font-family: inherit;
   border: var(--component-button-border_width-default) solid transparent;
+  padding: 0 var(--button-vertical-padding);
   text-align: center;
   box-sizing: border-box;
   letter-spacing: var(--typography-default-letter-spacing);
@@ -37,7 +39,7 @@
   height: var(--component-button-size-height-small);
   font-size: var(--font_size-400);
   --icon-size: var(--component-button-size-icon-small);
-  padding: 0 var(--component-button-space-padding-x-small);
+  --button-vertical-padding: var(--component-button-space-padding-x-small);
   gap: var(--component-button-space-gap-small);
 }
 
@@ -46,7 +48,7 @@
   min-width: var(--component-button-size-height-medium);
   font-size: var(--font_size-500);
   --icon-size: var(--component-button-size-icon-medium);
-  padding: 0 var(--component-button-space-padding-x-medium);
+  --button-vertical-padding: var(--component-button-space-padding-x-medium);
   gap: var(--component-button-space-gap-medium);
 }
 
@@ -55,7 +57,7 @@
   min-width: var(--component-button-size-height-large);
   font-size: var(--font_size-700);
   --icon-size: var(--component-button-size-icon-large);
-  padding: 0 var(--component-button-space-padding-x-large);
+  --button-vertical-padding: var(--component-button-space-padding-x-large);
   gap: var(--component-button-space-gap-large);
 }
 
@@ -84,6 +86,7 @@
 
 .button--quiet {
   border-radius: 50px;
+  padding: 0 calc(var(--button-vertical-padding) / 3);
   background-color: transparent;
 }
 

--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -3,7 +3,7 @@
 
   all: initial; /* reset all styles to default, to avoid style overrides/surprises caused by other css (from Design system v1 f.ex) */
   font-family: inherit;
-  border: 0;
+  border: var(--component-button-border_width-default) solid transparent;
   text-align: center;
   box-sizing: border-box;
   letter-spacing: var(--typography-default-letter-spacing);
@@ -19,10 +19,8 @@
   outline-offset: var(--border_width-standard);
 }
 
-.button:focus {
-  outline: var(--interactive_components-colors-focus_outline) solid
-    var(--border_width-standard);
-  outline-offset: var(--border_width-standard);
+.button:focus:not(:focus-visible) {
+  outline: none;
 }
 
 .button:disabled {
@@ -61,23 +59,32 @@
   gap: var(--component-button-space-gap-large);
 }
 
+.button--full-width {
+  width: 100%;
+}
+
+.button--dashed-border {
+  border-style: dashed;
+}
+
+.button--only-icon {
+  padding: 0.5rem;
+}
+
 .button--filled {
   border-radius: 3px;
   color: var(--component-button-filled-color-text-all);
   fill: var(--component-button-filled-color-text-all);
-  border: var(--component-button-border_width-default) solid transparent;
 }
 
 .button--outline {
   border-radius: 3px;
   background-color: transparent;
-  border: var(--component-button-border_width-default) solid transparent;
 }
 
 .button--quiet {
   border-radius: 50px;
   background-color: transparent;
-  border: var(--component-button-border_width-default) solid transparent;
 }
 
 /* Filled button colors */
@@ -127,6 +134,28 @@
 
 .button--filled--danger:not(:disabled):active {
   background: var(--colors-red-800);
+}
+
+.button--filled--inverted {
+  color: var(--colors-blue-900);
+  fill: var(--colors-blue-900);
+  background: var(--colors-white);
+}
+
+.button--filled--inverted:not(:disabled):hover {
+  color: var(--colors-blue-900);
+  fill: var(--colors-blue-900);
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.button--filled--inverted:not(:disabled):active {
+  color: var(--colors-white);
+  fill: var(--colors-white);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.button--filled--inverted:focus-visible {
+  outline-color: var(--colors-white);
 }
 
 /* Outline button colors */
@@ -206,6 +235,27 @@
   background: var(--colors-red-500);
 }
 
+.button--outline--inverted {
+  color: var(--colors-white);
+  fill: var(--colors-white);
+  border-color: var(--colors-white);
+  background: transparent;
+}
+
+.button--outline--inverted:not(:disabled):hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.button--outline--inverted:not(:disabled):active {
+  color: var(--colors-blue-900);
+  fill: var(--colors-blue-900);
+  background: var(--colors-white);
+}
+
+.button--outline--inverted:focus-visible {
+  outline-color: var(--colors-white);
+}
+
 /* Quiet button colors */
 .button--quiet--primary {
   color: var(--component-button-quiet-primary-color-text-default);
@@ -273,6 +323,24 @@
   background: var(--colors-red-800);
 }
 
-.button--only-icon {
-  padding: 0.5rem;
+.button--quiet--inverted {
+  color: var(--colors-white);
+  fill: var(--colors-white);
+  background: transparent;
+}
+
+.button--quiet--inverted:not(:disabled):hover {
+  color: var(--colors-blue-900);
+  fill: var(--colors-blue-900);
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.button--quiet--inverted:not(:disabled):active {
+  color: var(--colors-blue-900);
+  fill: var(--colors-blue-900);
+  background: var(--colors-white);
+}
+
+.button--quiet--inverted:focus-visible {
+  outline-color: var(--colors-white);
 }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -20,6 +20,7 @@ export enum ButtonColor {
   Secondary = 'secondary',
   Success = 'success',
   Danger = 'danger',
+  Inverted = 'inverted',
 }
 
 export enum ButtonVariant {
@@ -32,6 +33,8 @@ interface ButtonCommonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant: ButtonVariant;
   color: ButtonColor;
   size?: ButtonSize;
+  fullWidth?: boolean;
+  dashedBorder?: boolean;
   iconPlacement?: 'right' | 'left';
 }
 
@@ -60,6 +63,8 @@ export const Button = ({
   color = ButtonColor.Primary,
   variant = ButtonVariant.Filled,
   size = ButtonSize.Small,
+  fullWidth = false,
+  dashedBorder = false,
   iconPlacement = 'left',
   iconName,
   svgIconComponent,
@@ -74,6 +79,8 @@ export const Button = ({
         classes[`button--${variant}`],
         classes[`button--${color}`],
         classes[`button--${variant}--${color}`],
+        { [classes['button--full-width']]: fullWidth },
+        { [classes['button--dashed-border']]: dashedBorder },
         { [classes[`button--only-icon`]]: !children && iconName },
       )}
       type={type}

--- a/src/components/Button/Stories/FilledButton.stories.tsx
+++ b/src/components/Button/Stories/FilledButton.stories.tsx
@@ -42,6 +42,20 @@ export default {
 } as ComponentMeta<typeof Button>;
 
 const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;
+const WithinContainerTemplate: ComponentStory<typeof Button> = (args) => (
+  <div
+    style={{
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      width: '500px',
+      height: '300px',
+      border: 'red solid 5px',
+    }}
+  >
+    <Button {...args} />
+  </div>
+);
 
 export const Primary = Template.bind({});
 Primary.args = {
@@ -131,6 +145,21 @@ SecondaryWithIconNoText.args = {
   iconName: 'Close',
 };
 SecondaryWithIconNoText.parameters = {
+  docs: {
+    description: {
+      story: '', // TODO: add story description, supports markdown
+    },
+  },
+};
+
+export const FullWidth = WithinContainerTemplate.bind({});
+FullWidth.args = {
+  color: ButtonColor.Primary,
+  iconName: 'AddCircle',
+  fullWidth: true,
+  children: `Secondary button`,
+};
+FullWidth.parameters = {
   docs: {
     description: {
       story: '', // TODO: add story description, supports markdown

--- a/src/components/Button/Stories/OutlineButton.stories.tsx
+++ b/src/components/Button/Stories/OutlineButton.stories.tsx
@@ -42,6 +42,20 @@ export default {
 } as ComponentMeta<typeof Button>;
 
 const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;
+const WithinContainerTemplate: ComponentStory<typeof Button> = (args) => (
+  <div
+    style={{
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      width: '500px',
+      height: '300px',
+      border: 'red solid 5px',
+    }}
+  >
+    <Button {...args} />
+  </div>
+);
 
 export const Primary = Template.bind({});
 Primary.args = {
@@ -95,7 +109,7 @@ Danger.parameters = {
   },
 };
 
-export const SuccessWithIcon = Template.bind({});
+export const SuccessWithIcon = WithinContainerTemplate.bind({});
 SuccessWithIcon.args = {
   color: ButtonColor.Success,
   iconName: 'Success',
@@ -131,6 +145,22 @@ SecondaryWithIconNoText.args = {
   iconName: 'Close',
 };
 SecondaryWithIconNoText.parameters = {
+  docs: {
+    description: {
+      story: '', // TODO: add story description, supports markdown
+    },
+  },
+};
+
+export const FullWidthAndDashedBorder = WithinContainerTemplate.bind({});
+FullWidthAndDashedBorder.args = {
+  color: ButtonColor.Primary,
+  iconName: 'AddCircle',
+  fullWidth: true,
+  dashedBorder: true,
+  children: `Secondary button`,
+};
+FullWidthAndDashedBorder.parameters = {
   docs: {
     description: {
       story: '', // TODO: add story description, supports markdown

--- a/src/components/Button/Stories/QuietButton.stories.tsx
+++ b/src/components/Button/Stories/QuietButton.stories.tsx
@@ -43,6 +43,20 @@ export default {
 } as ComponentMeta<typeof Button>;
 
 const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;
+const WithinContainerTemplate: ComponentStory<typeof Button> = (args) => (
+  <div
+    style={{
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      width: '500px',
+      height: '300px',
+      border: 'red solid 5px',
+    }}
+  >
+    <Button {...args} />
+  </div>
+);
 
 export const Primary = Template.bind({});
 Primary.args = {
@@ -132,6 +146,21 @@ SuccessWithIconNoText.args = {
   iconName: 'Success',
 };
 SuccessWithIconNoText.parameters = {
+  docs: {
+    description: {
+      story: '', // TODO: add story description, supports markdown
+    },
+  },
+};
+
+export const FullWidth = WithinContainerTemplate.bind({});
+FullWidth.args = {
+  color: ButtonColor.Primary,
+  iconName: 'AddCircle',
+  fullWidth: true,
+  children: `Secondary button`,
+};
+FullWidth.parameters = {
   docs: {
     description: {
       story: '', // TODO: add story description, supports markdown


### PR DESCRIPTION
After a review of the new button styles with UX resource, som changes were wanted:

- Added Inverted as a new color.
- Added `fullWidth` as an option to make the buttons width to fill its container.
- Added `dashedBorder` as an option to make the outline buttons border-style dashed.
- Fixed issue with outline being set when clicking the button.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
