### PR TITLE
Fix onChange bug on CheckboxGroup

### DIFF
--- a/src/components/CheckboxGroup/CheckboxGroup.test.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.test.tsx
@@ -57,7 +57,17 @@ describe('CheckboxGroup', () => {
     const onChange = jest.fn();
     render({ onChange });
     await act(() => user.click(screen.queryAllByRole('checkbox')[0]));
+    expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith([defaultProps.items[0].name]);
+    await act(() => user.click(screen.queryAllByRole('checkbox')[1]));
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(onChange).toHaveBeenCalledWith([
+      defaultProps.items[0].name,
+      defaultProps.items[1].name,
+    ]);
+    await act(() => user.click(screen.queryAllByRole('checkbox')[0]));
+    expect(onChange).toHaveBeenCalledTimes(3);
+    expect(onChange).toHaveBeenCalledWith([defaultProps.items[1].name]);
   });
 
   it('Checkboxes should be checked if the "items" prop tells them to be', () => {

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -72,7 +72,7 @@ export const CheckboxGroup = ({
   );
 
   const firstRender = useRef(true);
-  const prevCheckedNames = useRef(checkedItems(items));
+  const prevCheckedNames = useRef(checkedNames);
 
   useEffect(() => {
     if (firstRender.current) {
@@ -83,6 +83,7 @@ export const CheckboxGroup = ({
       !arraysEqual(prevCheckedNames.current, checkedNames)
     ) {
       onChange(checkedNames);
+      prevCheckedNames.current = checkedNames;
     }
   }, [checkedNames, onChange, disabled]);
 

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useReducer } from 'react';
+import React, { useEffect, useReducer, useRef } from 'react';
 import cn from 'classnames';
 
 import { Checkbox, FieldSet } from '@/components';
 import type { CheckboxProps } from '@/components/Checkbox/Checkbox';
 import { FieldSetSize } from '@/components/FieldSet/FieldSet';
+import { arraysEqual } from '@/utils/arrayUtils';
 
 import classes from './CheckboxGroup.module.css';
 
@@ -70,10 +71,20 @@ export const CheckboxGroup = ({
     [items],
   );
 
-  useEffect(
-    () => (onChange && !disabled ? onChange(checkedNames) : undefined),
-    [checkedNames, onChange, disabled],
-  );
+  const firstRender = useRef(true);
+  const prevCheckedNames = useRef(checkedItems(items));
+
+  useEffect(() => {
+    if (firstRender.current) {
+      firstRender.current = false;
+    } else if (
+      onChange &&
+      !disabled &&
+      !arraysEqual(prevCheckedNames.current, checkedNames)
+    ) {
+      onChange(checkedNames);
+    }
+  }, [checkedNames, onChange, disabled]);
 
   return (
     <FieldSet

--- a/src/components/CheckboxGroup/index.ts
+++ b/src/components/CheckboxGroup/index.ts
@@ -1,1 +1,1 @@
-export { CheckboxGroup } from './CheckboxGroup';
+export { CheckboxGroup, CheckboxGroupVariant } from './CheckboxGroup';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -20,5 +20,5 @@ export { Map } from './Map';
 export { Checkbox } from './Checkbox';
 export { TextArea } from './TextArea';
 export type { IconVariant, ReadOnlyVariant } from './_InputWrapper';
-export { CheckboxGroup } from './CheckboxGroup';
+export { CheckboxGroup, CheckboxGroupVariant } from './CheckboxGroup';
 export { FieldSet, FieldSetSize } from './FieldSet';

--- a/src/utils/arrayUtils.test.ts
+++ b/src/utils/arrayUtils.test.ts
@@ -1,0 +1,51 @@
+import { arraysEqual } from '@/utils/arrayUtils';
+
+describe('arrayUtils', () => {
+  describe('arraysEqual', () => {
+    it('Returns true if arrays are the same', () => {
+      const array = [1, 2, 3];
+      expect(arraysEqual(array, array)).toBe(true);
+    });
+
+    it('Returns true if arrays have equal content', () => {
+      expect(arraysEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+      expect(arraysEqual(['a', 'b', 'c'], ['a', 'b', 'c'])).toBe(true);
+      expect(arraysEqual([true, false], [true, false])).toBe(true);
+      expect(arraysEqual([1, 'b', true], [1, 'b', true])).toBe(true);
+    });
+
+    it('Returns true if both arrays are undefined', () => {
+      expect(arraysEqual(undefined, undefined)).toBe(true);
+    });
+
+    it('Returns false if one of the arrays is undefined', () => {
+      expect(arraysEqual([1, 2, 3], undefined)).toBe(false);
+      expect(arraysEqual(undefined, [1, 2, 3])).toBe(false);
+    });
+
+    it('Returns false if the arrays have different length', () => {
+      expect(arraysEqual([1, 2, 3], [1, 2, 3, 4])).toBe(false);
+      expect(arraysEqual([1, 2, 3, 4], [1, 2, 3])).toBe(false);
+    });
+
+    it('Returns false if the arrays have different order', () => {
+      expect(arraysEqual([1, 2, 3], [1, 3, 2])).toBe(false);
+      expect(arraysEqual([3, 2, 1], [2, 3, 1])).toBe(false);
+      expect(arraysEqual(['a', 'b', 'c'], ['c', 'a', 'b'])).toBe(false);
+      expect(arraysEqual([true, false], [false, true])).toBe(false);
+    });
+
+    it('Returns false if the arrays have different content', () => {
+      expect(arraysEqual([1, 2, 3], [1, 2, 4])).toBe(false);
+      expect(arraysEqual<string | number>([1, 2, 3], ['a', 'b', 'c'])).toBe(
+        false,
+      );
+      expect(arraysEqual<string | number>([1, 2, 3], ['1', '2', '3'])).toBe(
+        false,
+      );
+      expect(arraysEqual(['a', 'b', 'c'], ['å', 'b', 'c'])).toBe(false);
+      expect(arraysEqual([true, false], [true, true])).toBe(false);
+      expect(arraysEqual([1, 'b', true], [0, 'b', true])).toBe(false);
+    });
+  });
+});

--- a/src/utils/arrayUtils.ts
+++ b/src/utils/arrayUtils.ts
@@ -1,0 +1,10 @@
+// Checks if content of arrays is equal
+export function arraysEqual<T>(array1?: T[], array2?: T[]): boolean {
+  if (array1 === array2) return true;
+  if (array1 === undefined || array2 === undefined) return false;
+  if (array1.length !== array2.length) return false;
+  for (const i in array1) {
+    if (array1[i] !== array2[i]) return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Description
The `onChange` handler on the checkbox group is now called on first render and sometimes when there are no real changes, since the `useEffect` hook doesn't check the actual values of array dependencies. This pull request should solve this by adding a `useRef` for checking if it is the first render and an `arraysEqual` function to check for differences inside the `checkedNames` array. Also, it exports CheckboxGroupVariant so that it can be used by the consumer.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
