### PR TITLE
Support button to be used as popover trigger

### DIFF
--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -3,7 +3,8 @@ import { render as renderRtl, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import type { ButtonProps } from './Button';
-import { ButtonColor, ButtonSize, Button, ButtonVariant } from './Button';
+
+import { ButtonColor, ButtonSize, Button, ButtonVariant } from './';
 
 const user = userEvent.setup();
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,5 @@
 import React, {
+  forwardRef,
   type ButtonHTMLAttributes,
   type PropsWithChildren,
 } from 'react';
@@ -30,8 +31,8 @@ export enum ButtonVariant {
 }
 
 interface ButtonCommonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  variant: ButtonVariant;
-  color: ButtonColor;
+  variant?: ButtonVariant;
+  color?: ButtonColor;
   size?: ButtonSize;
   fullWidth?: boolean;
   dashedBorder?: boolean;
@@ -58,21 +59,25 @@ const renderIcon = (iconName?: string, iconComponent?: JSX.Element) => {
   }
 };
 
-export const Button = ({
-  children,
-  color = ButtonColor.Primary,
-  variant = ButtonVariant.Filled,
-  size = ButtonSize.Small,
-  fullWidth = false,
-  dashedBorder = false,
-  iconPlacement = 'left',
-  iconName,
-  svgIconComponent,
-  type = 'button',
-  ...restHTMLProps
-}: PropsWithChildren<ButtonProps>) => {
+const Button = (
+  {
+    children,
+    color = ButtonColor.Primary,
+    variant = ButtonVariant.Filled,
+    size = ButtonSize.Small,
+    fullWidth = false,
+    dashedBorder = false,
+    iconPlacement = 'left',
+    iconName,
+    svgIconComponent,
+    type = 'button',
+    ...restHTMLProps
+  }: PropsWithChildren<ButtonProps>,
+  ref?: React.LegacyRef<HTMLButtonElement> | undefined,
+) => {
   return (
     <button
+      ref={ref}
       className={cn(
         classes.button,
         classes[`button--${size}`],
@@ -93,3 +98,5 @@ export const Button = ({
     </button>
   );
 };
+
+export default forwardRef(Button);

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -73,7 +73,7 @@ const Button = (
     type = 'button',
     ...restHTMLProps
   }: PropsWithChildren<ButtonProps>,
-  ref?: React.LegacyRef<HTMLButtonElement> | undefined,
+  ref?: React.Ref<HTMLButtonElement> | undefined,
 ) => {
   return (
     <button

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -1,1 +1,6 @@
-export { Button, ButtonVariant, ButtonColor, ButtonSize } from './Button';
+export {
+  default as Button,
+  ButtonVariant,
+  ButtonColor,
+  ButtonSize,
+} from './Button';

--- a/src/components/Panel/PopoverPanel.stories.tsx
+++ b/src/components/Panel/PopoverPanel.stories.tsx
@@ -56,7 +56,14 @@ const Template: ComponentStory<typeof PopoverPanel> = (args) => {
         side={args.side}
         title={args.title}
         open={open}
-        trigger={<button>Åpne</button>}
+        trigger={
+          <Button
+            variant={ButtonVariant.Filled}
+            color={ButtonColor.Primary}
+          >
+            Åpne
+          </Button>
+        }
         onOpenChange={setOpen}
         showPointer={args.showPointer}
         showIcon={args.showIcon}


### PR DESCRIPTION
Potential Breaking change by using forwardRef:
https://reactjs.org/docs/forwarding-refs.html#note-for-component-library-maintainers

Use forwardRef to allow passing a reference to the html button which is needed by the popover component to use the button as a trigger.

Also make variant and color optional as they have default values.

## Related Issue(s)
- https://github.com/Altinn/app-frontend-react/issues/439

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
