### PR TITLE
Revert "chore(deps): update dependency rollup-plugin-dts to v5"

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "rollup": "2.79.1",
-    "rollup-plugin-dts": "5.0.0",
+    "rollup-plugin-dts": "4.2.3",
     "rollup-plugin-peer-deps-external": "2.2.4",
     "rollup-plugin-postcss": "4.0.2",
     "semver": "7.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -88,7 +88,7 @@ __metadata:
     react-leaflet: ^4.0.1
     react-number-format: ^5.1.1
     rollup: 2.79.1
-    rollup-plugin-dts: 5.0.0
+    rollup-plugin-dts: 4.2.3
     rollup-plugin-peer-deps-external: 2.2.4
     rollup-plugin-postcss: 4.0.2
     semver: 7.3.8
@@ -13716,7 +13716,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magic-string@npm:^0.26.4, magic-string@npm:^0.26.7":
+"magic-string@npm:^0.26.4, magic-string@npm:^0.26.6":
   version: 0.26.7
   resolution: "magic-string@npm:0.26.7"
   dependencies:
@@ -17180,19 +17180,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup-plugin-dts@npm:5.0.0":
-  version: 5.0.0
-  resolution: "rollup-plugin-dts@npm:5.0.0"
+"rollup-plugin-dts@npm:4.2.3":
+  version: 4.2.3
+  resolution: "rollup-plugin-dts@npm:4.2.3"
   dependencies:
     "@babel/code-frame": ^7.18.6
-    magic-string: ^0.26.7
+    magic-string: ^0.26.6
   peerDependencies:
-    rollup: ^3.0.0
+    rollup: ^2.55
     typescript: ^4.1
   dependenciesMeta:
     "@babel/code-frame":
       optional: true
-  checksum: feb2d614528c255ee698120be0fd404b0a4fa312362a3d687d76551157464decc66be6dfecb624c42bc64a9e6298ed21e13e689dc9b144acab8294cd08a53455
+  checksum: b1de94202d0574e7c12105bf0d013e7142c1b9b74d6b83d194d870dcdc281e90cff45ed47a0ab1c62280cc25e75f522e1278ec0ba89c8f75b8bcb56dc98c2c63
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts Altinn/altinn-design-system#170

I was a little quick to push this button since the tests passed, but we should await this change until rollup v3 hits in #169