### PR TITLE
Improvements on Select component

### DIFF
--- a/src/components/Select/MultiSelectItem.module.css
+++ b/src/components/Select/MultiSelectItem.module.css
@@ -28,6 +28,11 @@
   background-color: var(--delete_cross_box-color-hover);
 }
 
+.multi-select-item__delete-button:focus-visible {
+  background-color: var(--delete_cross_box-color-hover);
+  outline: var(--focus_visible-outline);
+}
+
 .multi-select-item__delete-button__cross {
   background-color: var(--multiselect_item_delete_cross-color);
   clip-path: var(--delete_cross-clip_path);

--- a/src/components/Select/Select.module.css
+++ b/src/components/Select/Select.module.css
@@ -26,9 +26,9 @@
   --arrow-border_left: 1px solid #022f5180;
   --arrow-color: var(--colors-blue-900);
   --arrow-height_to_width_fraction: calc(8 / 14);
-  --arrow-margin_left: 4px;
-  --arrow-padding: 6px;
+  --arrow-horizontal_padding: 6px;
   --arrow-size: 14px;
+  --arrow_wrapper-margin: 4px;
   --field-height-inside: calc(
     var(--field-height) - var(--component-input-border_width-default) * 2
   );
@@ -68,6 +68,8 @@
   --option-outline-focus: none;
   --option-padding_left: 12px;
   --singleselect_field-padding_left: 12px;
+  --focus_visible-outline: 2px auto
+    var(--interactive_components-colors-focus_outline);
 
   font-size: var(--font_size);
   line-height: var(--line-height);
@@ -87,8 +89,7 @@
 }
 
 .select--using-keyboard {
-  --option-outline-focus: 2px auto
-    var(--interactive_components-colors-focus_outline);
+  --option-outline-focus: var(--focus_visible-outline);
 }
 
 .select__field__button {
@@ -130,11 +131,25 @@
   padding: var(--multiselect_items-padding);
 }
 
+.select--multiple .select__field__button:focus-visible {
+  outline: var(--focus_visible-outline);
+}
+
 .select__field__arrow-wrapper {
+  --arrow-height: calc(
+    var(--arrow-size) * var(--arrow-height_to_width_fraction)
+  );
+  --arrow-vertical_padding: calc(
+    (var(--field-height-inside) - var(--arrow-height)) / 2 -
+      var(--arrow_wrapper-margin)
+  );
   border-left: var(--arrow-border_left);
   box-sizing: border-box;
-  margin-left: var(--arrow-margin_left);
-  padding: var(--arrow-padding);
+  display: flex;
+  margin-bottom: var(--arrow_wrapper-margin);
+  margin-left: var(--arrow_wrapper-margin);
+  margin-top: var(--arrow_wrapper-margin);
+  padding: var(--arrow-vertical_padding) var(--arrow-horizontal_padding);
 }
 
 .select__field__arrow-wrapper__arrow {
@@ -148,22 +163,26 @@
     2.57% 29.13%
   );
   display: inline-block;
-  height: calc(var(--arrow-size) * var(--arrow-height_to_width_fraction));
+  height: var(--arrow-height);
   width: var(--arrow-size);
 }
 
 .select--multiple__field__delete-button {
-  height: var(--delete_cross_box-size);
-  width: var(--delete_cross_box-size);
-  padding: calc((var(--delete_cross_box-size) - var(--delete_cross-size)) / 2);
-  border: none;
-  border-radius: var(--delete_cross_box-border_radius);
   background: none;
+  border-radius: var(--delete_cross_box-border_radius);
+  border: none;
   cursor: var(--interactive_element-cursor);
+  height: var(--delete_cross_box-size);
+  padding: calc((var(--delete_cross_box-size) - var(--delete_cross-size)) / 2);
+  width: var(--delete_cross_box-size);
 }
 
 .select--multiple__field__delete-button:disabled {
   cursor: auto;
+}
+
+.select--multiple__field__delete-button:focus-visible {
+  outline: var(--focus_visible-outline);
 }
 
 .select--multiple__field__delete-button:hover:not(:disabled) {

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -11,21 +11,21 @@ const figmaLink =
   'https://www.figma.com/file/vpM9dqqQPHqU6ogfKp5tlr/DDS---Core-Components?node-id=7538%3A45627';
 
 const defaultOptions: SingleSelectOption[] = [
-  { displayName: 'Agder', value: 'Agder' },
-  { displayName: 'Innlandet', value: 'Innlandet' },
-  { displayName: 'Møre og Romsdal', value: 'Møre og Romsdal' },
-  { displayName: 'Nordland', value: 'Nordland' },
-  { displayName: 'Oslo', value: 'Oslo' },
-  { displayName: 'Rogaland', value: 'Rogaland' },
-  { displayName: 'Vestfold og Telemark', value: 'Vestfold og Telemark' },
-  { displayName: 'Troms og Finnmark', value: 'Troms og Finnmark' },
-  { displayName: 'Trøndelag', value: 'Trøndelag' },
-  { displayName: 'Vestland', value: 'Vestland' },
-  { displayName: 'Viken', value: 'Viken' },
+  { label: 'Agder', value: 'Agder' },
+  { label: 'Innlandet', value: 'Innlandet' },
+  { label: 'Møre og Romsdal', value: 'Møre og Romsdal' },
+  { label: 'Nordland', value: 'Nordland' },
+  { label: 'Oslo', value: 'Oslo' },
+  { label: 'Rogaland', value: 'Rogaland' },
+  { label: 'Vestfold og Telemark', value: 'Vestfold og Telemark' },
+  { label: 'Troms og Finnmark', value: 'Troms og Finnmark' },
+  { label: 'Trøndelag', value: 'Trøndelag' },
+  { label: 'Vestland', value: 'Vestland' },
+  { label: 'Viken', value: 'Viken' },
 ];
 
 const multipleSelectOptions: MultiSelectOption[] = defaultOptions.map(
-  (option) => ({ ...option, deleteButtonLabel: 'Slett ' + option.displayName }),
+  (option) => ({ ...option, deleteButtonLabel: 'Slett ' + option.label }),
 );
 
 export default {

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -13,15 +13,15 @@ import { Select } from './Select';
 const user = userEvent.setup();
 
 const singleSelectOptions: SingleSelectOption[] = [
-  { displayName: 'Test 1', value: 'test1' },
-  { displayName: 'Test 2', value: 'test2' },
-  { displayName: 'Test 3', value: 'test3' },
+  { label: 'Test 1', value: 'test1' },
+  { label: 'Test 2', value: 'test2' },
+  { label: 'Test 3', value: 'test3' },
 ];
 
 const multiSelectOptions: Required<MultiSelectOption>[] = [
-  { displayName: 'Test 1', value: 'test1', deleteButtonLabel: 'Delete test 1' },
-  { displayName: 'Test 2', value: 'test2', deleteButtonLabel: 'Delete test 2' },
-  { displayName: 'Test 3', value: 'test3', deleteButtonLabel: 'Delete test 3' },
+  { label: 'Test 1', value: 'test1', deleteButtonLabel: 'Delete test 1' },
+  { label: 'Test 2', value: 'test2', deleteButtonLabel: 'Delete test 2' },
+  { label: 'Test 3', value: 'test3', deleteButtonLabel: 'Delete test 3' },
 ];
 
 const defaultSingleSelectProps: SingleSelectProps = {
@@ -36,76 +36,52 @@ describe('Select', () => {
   describe('Single select', () => {
     it('Renders a select box', () => {
       renderSingleSelect();
-      expect(screen.getByRole('combobox')).toBeTruthy();
+      expect(getCombobox()).toBeTruthy();
     });
 
     it('Renders correct number of options', () => {
       renderSingleSelect();
-      expect(screen.queryAllByRole('option')).toHaveLength(
-        singleSelectOptions.length,
-      );
+      expect(getOptions()).toHaveLength(singleSelectOptions.length);
     });
 
     it('Selects given value', () => {
       const selectedOptionIndex = 1;
       const selectedOption = singleSelectOptions[selectedOptionIndex];
       renderSingleSelect({ value: selectedOption.value });
-      expect(screen.getByRole('combobox')).toHaveTextContent(
-        selectedOption.displayName,
-      );
-      screen.getAllByRole('option').forEach((option, i) => {
-        expect(option).toHaveAttribute(
-          'aria-selected',
-          selectedOptionIndex === i ? 'true' : 'false',
-        );
-      });
+      expectSelectedValue(selectedOption);
+      expectSelectedOptions((i) => selectedOptionIndex === i);
     });
 
     it('Is not expanded by default', async () => {
       renderSingleSelect();
-      expect(screen.getByRole('combobox')).toHaveAttribute(
-        'aria-expanded',
-        'false',
-      );
+      expect(getCombobox()).toHaveAttribute('aria-expanded', 'false');
     });
 
     it('Expands when user clicks on it', async () => {
       renderSingleSelect();
       await act(() => user.click(screen.getByRole('combobox')));
-      expect(screen.getByRole('combobox')).toHaveAttribute(
-        'aria-expanded',
-        'true',
-      );
+      expect(getCombobox()).toHaveAttribute('aria-expanded', 'true');
     });
 
     it('Closes when user selects an option', async () => {
       renderSingleSelect();
       await act(() => user.click(screen.getByRole('combobox')));
       await act(() => user.click(screen.getAllByRole('option')[1]));
-      expect(screen.getByRole('combobox')).toHaveAttribute(
-        'aria-expanded',
-        'false',
-      );
+      expect(getCombobox()).toHaveAttribute('aria-expanded', 'false');
     });
 
     it('Expands when combobox is focused and user presses an arrow key', async () => {
       renderSingleSelect();
       await act(() => user.click(screen.getByRole('combobox')));
       await act(() => user.keyboard('ArrowUp'));
-      expect(screen.getByRole('combobox')).toHaveAttribute(
-        'aria-expanded',
-        'true',
-      );
+      expect(getCombobox()).toHaveAttribute('aria-expanded', 'true');
     });
 
     it('Keeps expansion when user navigates through the options using keyboard', async () => {
       renderSingleSelect();
       await act(() => user.click(screen.getByRole('combobox')));
       await act(() => user.keyboard('{ArrowDown}'));
-      expect(screen.getByRole('combobox')).toHaveAttribute(
-        'aria-expanded',
-        'true',
-      );
+      expect(getCombobox()).toHaveAttribute('aria-expanded', 'true');
     });
 
     it('Closes when user clicks outside of the element', async () => {
@@ -116,47 +92,31 @@ describe('Select', () => {
         </>,
       );
       await act(() => user.click(screen.getByRole('combobox')));
-      expect(screen.getByRole('combobox')).toHaveAttribute(
-        'aria-expanded',
-        'true',
-      );
+      expect(getCombobox()).toHaveAttribute('aria-expanded', 'true');
       await act(() => user.click(screen.getByTestId('some-element-outside')));
-      expect(screen.getByRole('combobox')).toHaveAttribute(
-        'aria-expanded',
-        'false',
-      );
+      expect(getCombobox()).toHaveAttribute('aria-expanded', 'false');
     });
 
     it('Closes when tab is used to navigate away', async () => {
       renderSingleSelect();
       await act(() => user.click(screen.getByRole('combobox')));
-      expect(screen.getByRole('combobox')).toHaveAttribute(
-        'aria-expanded',
-        'true',
-      );
+      expect(getCombobox()).toHaveAttribute('aria-expanded', 'true');
       await act(() => user.tab());
-      expect(screen.getByRole('combobox')).toHaveAttribute(
-        'aria-expanded',
-        'false',
-      );
+      expect(getCombobox()).toHaveAttribute('aria-expanded', 'false');
     });
 
     it('Changes value when user clicks on another option', async () => {
       renderSingleSelect();
       await act(() => user.click(screen.getByRole('combobox')));
       await act(() => user.click(screen.getAllByRole('option')[1]));
-      expect(screen.getByRole('combobox')).toHaveTextContent(
-        singleSelectOptions[1].displayName,
-      );
+      expectSelectedValue(singleSelectOptions[1]);
     });
 
     it('Selects first option when nothing is selected and user presses ArrowDown key', async () => {
       renderSingleSelect();
       await act(() => user.click(screen.getByRole('combobox')));
       await act(() => user.keyboard('{ArrowDown}'));
-      expect(screen.getByRole('combobox')).toHaveTextContent(
-        singleSelectOptions[0].displayName,
-      );
+      expectSelectedValue(singleSelectOptions[0]);
     });
 
     it('Selects option navigated to by arrow keys', async () => {
@@ -164,39 +124,27 @@ describe('Select', () => {
       await act(() => user.click(screen.getByRole('combobox')));
       await act(() => user.keyboard('{ArrowDown}'));
       await act(() => user.keyboard('{ArrowDown}'));
-      expect(screen.getByRole('combobox')).toHaveTextContent(
-        singleSelectOptions[1].displayName,
-      );
+      expectSelectedValue(singleSelectOptions[1]);
       await act(() => user.keyboard('{ArrowDown}'));
-      expect(screen.getByRole('combobox')).toHaveTextContent(
-        singleSelectOptions[2].displayName,
-      );
+      expectSelectedValue(singleSelectOptions[2]);
       await act(() => user.keyboard('{ArrowUp}'));
-      expect(screen.getByRole('combobox')).toHaveTextContent(
-        singleSelectOptions[1].displayName,
-      );
+      expectSelectedValue(singleSelectOptions[1]);
       await act(() => user.keyboard('{ArrowUp}'));
-      expect(screen.getByRole('combobox')).toHaveTextContent(
-        singleSelectOptions[0].displayName,
-      );
+      expectSelectedValue(singleSelectOptions[0]);
     });
 
     it('Selects last option when nothing is selected and user presses ArrowUp key', async () => {
       renderSingleSelect();
-      await act(() => user.click(screen.getByRole('combobox')));
+      await act(() => user.click(getCombobox()));
       await act(() => user.keyboard('{ArrowUp}'));
-      expect(screen.getByRole('combobox')).toHaveTextContent(
-        singleSelectOptions[singleSelectOptions.length - 1].displayName,
-      );
+      expectSelectedValue(singleSelectOptions[singleSelectOptions.length - 1]);
     });
 
     it('Starts navigation from selected option when navigating with arrow keys', async () => {
       renderSingleSelect({ value: singleSelectOptions[2].value });
       await act(() => user.click(screen.getByRole('combobox')));
       await act(() => user.keyboard('{ArrowUp}'));
-      expect(screen.getByRole('combobox')).toHaveTextContent(
-        singleSelectOptions[1].displayName,
-      );
+      expectSelectedValue(singleSelectOptions[1]);
     });
 
     it('Calls onChange handler with new value when it changes', async () => {
@@ -225,25 +173,19 @@ describe('Select', () => {
 
     it('Gets correct state according to keyboard/mouse navigation', async () => {
       renderSingleSelect();
-      expect(screen.getByTestId('select-root').classList).not.toContain(
-        'select--using-keyboard',
-      );
+      expect(getRoot().classList).not.toContain('select--using-keyboard');
       await act(() => user.tab());
-      expect(screen.getByTestId('select-root').classList).toContain(
-        'select--using-keyboard',
-      );
+      expect(getRoot().classList).toContain('select--using-keyboard');
       await act(() => user.click(document.body));
-      expect(screen.getByTestId('select-root').classList).not.toContain(
-        'select--using-keyboard',
-      );
+      expect(getRoot().classList).not.toContain('select--using-keyboard');
     });
 
     it('Throws an error if there are duplicate values', () => {
       const renderFn = () =>
         renderSingleSelect({
           options: [
-            { displayName: 'Test 1', value: 'duplicated value' },
-            { displayName: 'Test 2', value: 'duplicated value' },
+            { label: 'Test 1', value: 'duplicated value' },
+            { label: 'Test 2', value: 'duplicated value' },
           ],
         });
       jest.spyOn(console, 'error').mockImplementation(jest.fn()); // Keeps the console output clean
@@ -269,66 +211,54 @@ describe('Select', () => {
       expect(screen.queryByRole('label')).toBeFalsy();
       expect(screen.getByLabelText(label)).toBeTruthy();
     });
+
+    const expectSelectedValue = (option: SingleSelectOption) => {
+      expect(getCombobox()).toHaveValue(option.value);
+      expect(getCombobox()).toHaveTextContent(option.label);
+    };
   });
 
   describe('Multiple select', () => {
     it('Renders a select box', () => {
       renderMultiSelect();
-      expect(screen.getByRole('combobox')).toBeTruthy();
+      expect(getCombobox()).toBeTruthy();
     });
 
     it('Renders correct number of options', () => {
       renderMultiSelect();
-      expect(screen.queryAllByRole('option')).toHaveLength(
-        multiSelectOptions.length,
-      );
+      expect(getOptions()).toHaveLength(multiSelectOptions.length);
     });
 
     it('Is not expanded by default', async () => {
       renderMultiSelect();
-      expect(screen.getByRole('combobox')).toHaveAttribute(
-        'aria-expanded',
-        'false',
-      );
+      expect(getCombobox()).toHaveAttribute('aria-expanded', 'false');
     });
 
     it('Expands when user clicks on it', async () => {
       renderMultiSelect();
       await act(() => user.click(screen.getByRole('combobox')));
-      expect(screen.getByRole('combobox')).toHaveAttribute(
-        'aria-expanded',
-        'true',
-      );
+      expect(getCombobox()).toHaveAttribute('aria-expanded', 'true');
     });
 
     it('Expands when combobox is focused and user presses an arrow key', async () => {
       renderMultiSelect();
       await act(() => user.click(screen.getByRole('combobox')));
       await act(() => user.keyboard('ArrowUp'));
-      expect(screen.getByRole('combobox')).toHaveAttribute(
-        'aria-expanded',
-        'true',
-      );
+      expect(getCombobox()).toHaveAttribute('aria-expanded', 'true');
     });
 
     it('Keeps expansion when user selects an option', async () => {
       renderMultiSelect();
       await act(() => user.click(screen.getByRole('combobox')));
       await act(() => user.click(screen.getAllByRole('option')[1]));
-      expect(screen.getByRole('combobox')).toHaveAttribute(
-        'aria-expanded',
-        'true',
-      );
+      expect(getCombobox()).toHaveAttribute('aria-expanded', 'true');
     });
 
     it('Keeps expansion when user navigates through the options using keyboard', async () => {
       renderMultiSelect();
       await act(() => user.click(screen.getByRole('combobox')));
       await act(() => user.keyboard('{ArrowDown}'));
-      expect(screen.getByRole('combobox')).toHaveAttribute(
-        'aria-expanded',
-        'true',
-      );
+      expect(getCombobox()).toHaveAttribute('aria-expanded', 'true');
     });
 
     it('Closes when user clicks outside of the element', async () => {
@@ -339,84 +269,55 @@ describe('Select', () => {
         </>,
       );
       await act(() => user.click(screen.getByRole('combobox')));
-      expect(screen.getByRole('combobox')).toHaveAttribute(
-        'aria-expanded',
-        'true',
-      );
+      expect(getCombobox()).toHaveAttribute('aria-expanded', 'true');
       await act(() => user.click(screen.getByTestId('some-element-outside')));
-      expect(screen.getByRole('combobox')).toHaveAttribute(
-        'aria-expanded',
-        'false',
-      );
+      expect(getCombobox()).toHaveAttribute('aria-expanded', 'false');
     });
 
     it('Closes when tab is used to navigate away', async () => {
       renderMultiSelect();
       await act(() => user.click(screen.getByRole('combobox')));
-      expect(screen.getByRole('combobox')).toHaveAttribute(
-        'aria-expanded',
-        'true',
-      );
+      expect(getCombobox()).toHaveAttribute('aria-expanded', 'true');
       await act(() => user.tab());
-      expect(screen.getByRole('combobox')).toHaveAttribute(
-        'aria-expanded',
-        'false',
-      );
+      expect(getCombobox()).toHaveAttribute('aria-expanded', 'false');
     });
 
     it('Shows given selected options as selected', () => {
-      const selectedOptionIndices = [1, 2];
-      const selectedOptions = selectedOptionIndices.map(
-        (i) => multiSelectOptions[i],
-      );
-      const selectedValues = selectedOptions.map((o) => o.value);
+      const selectedOptIndices = [1, 2];
+      const selectedOpts = selectedOptIndices.map((i) => multiSelectOptions[i]);
+      const selectedValues = selectedOpts.map((o) => o.value);
       renderMultiSelect({ value: selectedValues });
-      screen.getAllByRole('option').forEach((o, i) => {
-        expect(o).toHaveAttribute(
-          'aria-selected',
-          selectedOptionIndices.includes(i) ? 'true' : 'false',
-        );
-      });
+      expectSelectedValues(selectedValues);
+      expectSelectedOptions((i) => selectedOptIndices.includes(i));
     });
 
     it('Focuses on first option when no option has focus and ArrowDown key is pressed', async () => {
       const { container } = renderMultiSelect();
-      await act(() => user.click(screen.getByRole('combobox')));
+      await act(() => user.click(getCombobox()));
       await act(() => user.keyboard('{ArrowDown}'));
-      expect(container.querySelector('[class*="focused"]')).toHaveTextContent(
-        multiSelectOptions[0].displayName,
-      );
+      expectFocusedOption(container, multiSelectOptions[0]);
     });
 
     it('Focuses on last option when no option has focus and ArrowUp key is pressed', async () => {
       const { container } = renderMultiSelect();
-      await act(() => user.click(screen.getByRole('combobox')));
+      await act(() => user.click(getCombobox()));
       await act(() => user.keyboard('{ArrowUp}'));
-      expect(container.querySelector('[class*="focused"]')).toHaveTextContent(
-        multiSelectOptions[multiSelectOptions.length - 1].displayName,
-      );
+      const lastOption = multiSelectOptions[multiSelectOptions.length - 1];
+      expectFocusedOption(container, lastOption);
     });
 
     it('Moves focus on arrow key click', async () => {
       const { container } = renderMultiSelect();
-      await act(() => user.click(screen.getByRole('combobox')));
+      await act(() => user.click(getCombobox()));
       await act(() => user.keyboard('{ArrowDown}'));
       await act(() => user.keyboard('{ArrowDown}'));
-      expect(container.querySelector('[class*="focused"]')).toHaveTextContent(
-        multiSelectOptions[1].displayName,
-      );
+      expectFocusedOption(container, multiSelectOptions[1]);
       await act(() => user.keyboard('{ArrowDown}'));
-      expect(container.querySelector('[class*="focused"]')).toHaveTextContent(
-        multiSelectOptions[2].displayName,
-      );
+      expectFocusedOption(container, multiSelectOptions[2]);
       await act(() => user.keyboard('{ArrowUp}'));
-      expect(container.querySelector('[class*="focused"]')).toHaveTextContent(
-        multiSelectOptions[1].displayName,
-      );
+      expectFocusedOption(container, multiSelectOptions[1]);
       await act(() => user.keyboard('{ArrowUp}'));
-      expect(container.querySelector('[class*="focused"]')).toHaveTextContent(
-        multiSelectOptions[0].displayName,
-      );
+      expectFocusedOption(container, multiSelectOptions[0]);
     });
 
     it('Does not move focus when first option is focused and ArrowUp key is pressed', async () => {
@@ -424,9 +325,7 @@ describe('Select', () => {
       await act(() => user.click(screen.getByRole('combobox')));
       await act(() => user.keyboard('{ArrowDown}'));
       await act(() => user.keyboard('{ArrowUp}'));
-      expect(container.querySelector('[class*="focused"]')).toHaveTextContent(
-        multiSelectOptions[0].displayName,
-      );
+      expectFocusedOption(container, multiSelectOptions[0]);
     });
 
     it('Does not move focus when last option is selected and ArrowDown key is pressed', async () => {
@@ -434,17 +333,14 @@ describe('Select', () => {
       await act(() => user.click(screen.getByRole('combobox')));
       await act(() => user.keyboard('{ArrowUp}'));
       await act(() => user.keyboard('{ArrowDown}'));
-      expect(container.querySelector('[class*="focused"]')).toHaveTextContent(
-        multiSelectOptions[multiSelectOptions.length - 1].displayName,
-      );
+      const lastOption = multiSelectOptions[multiSelectOptions.length - 1];
+      expectFocusedOption(container, lastOption);
     });
 
     it('Focuses on selected option if it is the first to become selected', async () => {
       const { container } = renderMultiSelect();
       await act(() => user.click(screen.getAllByRole('option')[1]));
-      expect(container.querySelector('[class*="focused"]')).toHaveTextContent(
-        multiSelectOptions[1].displayName,
-      );
+      expectFocusedOption(container, multiSelectOptions[1]);
     });
 
     it('Selects options on click', async () => {
@@ -453,31 +349,19 @@ describe('Select', () => {
       for (const index of optionIndicesToSelect) {
         await act(() => user.click(screen.getAllByRole('option')[index]));
       }
-      screen.getAllByRole('option').forEach((o, i) => {
-        expect(o).toHaveAttribute(
-          'aria-selected',
-          optionIndicesToSelect.includes(i) ? 'true' : 'false',
-        );
-      });
+      expectSelectedOptions((i) => optionIndicesToSelect.includes(i));
     });
 
     it('Unselects option on click', async () => {
       renderMultiSelect({ value: multiSelectOptions.map((o) => o.value) });
       const optionIndexToUnselect = 1;
-      await act(() =>
-        user.click(screen.getAllByRole('option')[optionIndexToUnselect]),
-      );
-      screen.getAllByRole('option').forEach((o, i) => {
-        expect(o).toHaveAttribute(
-          'aria-selected',
-          i === optionIndexToUnselect ? 'false' : 'true',
-        );
-      });
+      await act(() => user.click(getOptions()[optionIndexToUnselect]));
+      expectSelectedOptions((i) => i !== optionIndexToUnselect);
     });
 
     it('Selects options on enter key press', async () => {
       renderMultiSelect();
-      await act(() => user.click(screen.getByRole('combobox')));
+      await act(() => user.click(getCombobox()));
       await act(() => user.keyboard('{ArrowDown}'));
       await act(() => user.keyboard('{Enter}'));
       await act(() => user.keyboard('{ArrowDown}'));
@@ -487,6 +371,10 @@ describe('Select', () => {
       expect(optionElements[0]).toHaveAttribute('aria-selected', 'true');
       expect(optionElements[1]).toHaveAttribute('aria-selected', 'false');
       expect(optionElements[2]).toHaveAttribute('aria-selected', 'true');
+      expectSelectedValues([
+        multiSelectOptions[0].value,
+        multiSelectOptions[2].value,
+      ]);
     });
 
     it('Unselects option on enter key press', async () => {
@@ -499,6 +387,10 @@ describe('Select', () => {
       expect(optionElements[0]).toHaveAttribute('aria-selected', 'true');
       expect(optionElements[1]).toHaveAttribute('aria-selected', 'false');
       expect(optionElements[2]).toHaveAttribute('aria-selected', 'true');
+      expectSelectedValues([
+        multiSelectOptions[0].value,
+        multiSelectOptions[2].value,
+      ]);
     });
 
     it('Displays delete button with given name', async () => {
@@ -512,35 +404,25 @@ describe('Select', () => {
       const deleteButtonLabel = 'Delete all';
       renderMultiSelect({ value: allValues, deleteButtonLabel });
       await act(() => user.click(screen.getByLabelText(deleteButtonLabel)));
-      screen.getAllByRole('option').forEach((o) => {
-        expect(o).toHaveAttribute('aria-selected', 'false');
-      });
+      expectSelectedValues([]);
+      expectSelectedOptions(() => false);
     });
 
     it('Unselects option when individual delete button is clicked', async () => {
-      renderMultiSelect({ value: multiSelectOptions.map((o) => o.value) });
+      const value = multiSelectOptions.map((o) => o.value);
+      renderMultiSelect({ value });
       const optionIndexToUnselect = 1;
-      await act(() =>
-        user.click(
-          screen.getByLabelText(
-            multiSelectOptions[optionIndexToUnselect].deleteButtonLabel,
-          ),
-        ),
-      );
-      screen.getAllByRole('option').forEach((o, i) => {
-        expect(o).toHaveAttribute(
-          'aria-selected',
-          i === optionIndexToUnselect ? 'false' : 'true',
-        );
-      });
+      const optionToUnselect = multiSelectOptions[optionIndexToUnselect];
+      const { deleteButtonLabel } = optionToUnselect;
+      await act(() => user.click(screen.getByLabelText(deleteButtonLabel)));
+      expectSelectedValues(value.filter((v, i) => i !== optionIndexToUnselect));
+      expectSelectedOptions((i) => i !== optionIndexToUnselect);
     });
 
     it('Enables common delete button if something is selected', () => {
       const deleteButtonLabel = 'Delete all';
-      renderMultiSelect({
-        deleteButtonLabel,
-        value: [multiSelectOptions[0].value],
-      });
+      const value = [multiSelectOptions[0].value];
+      renderMultiSelect({ deleteButtonLabel, value });
       expect(screen.getByLabelText(deleteButtonLabel)).toBeEnabled();
     });
 
@@ -593,40 +475,32 @@ describe('Select', () => {
     it('Enables individual delete buttons by default', async () => {
       const selectedOption = multiSelectOptions[0];
       renderMultiSelect({ value: [selectedOption.value] });
-      expect(
-        screen.getByLabelText(selectedOption.deleteButtonLabel),
-      ).toBeEnabled();
+      const { deleteButtonLabel } = selectedOption;
+      expect(screen.getByLabelText(deleteButtonLabel)).toBeEnabled();
     });
 
     it('Disables individual delete buttons when the "disabled" property is true', async () => {
       const selectedOption = multiSelectOptions[0];
       renderMultiSelect({ disabled: true, value: [selectedOption.value] });
-      expect(
-        screen.getByLabelText(selectedOption.deleteButtonLabel),
-      ).toBeDisabled();
+      const { deleteButtonLabel } = selectedOption;
+      expect(screen.getByLabelText(deleteButtonLabel)).toBeDisabled();
     });
 
     it('Gets correct state according to keyboard/mouse navigation', async () => {
       renderMultiSelect();
-      expect(screen.getByTestId('select-root').classList).not.toContain(
-        'select--using-keyboard',
-      );
+      expect(getRoot().classList).not.toContain('select--using-keyboard');
       await act(() => user.tab());
-      expect(screen.getByTestId('select-root').classList).toContain(
-        'select--using-keyboard',
-      );
+      expect(getRoot().classList).toContain('select--using-keyboard');
       await act(() => user.click(document.body));
-      expect(screen.getByTestId('select-root').classList).not.toContain(
-        'select--using-keyboard',
-      );
+      expect(getRoot().classList).not.toContain('select--using-keyboard');
     });
 
     it('Throws an error if there are duplicate values', () => {
       const renderFn = () =>
         renderMultiSelect({
           options: [
-            { displayName: 'Test 1', value: 'duplicated value' },
-            { displayName: 'Test 2', value: 'duplicated value' },
+            { label: 'Test 1', value: 'duplicated value' },
+            { label: 'Test 2', value: 'duplicated value' },
           ],
         });
       jest.spyOn(console, 'error').mockImplementation(jest.fn()); // Keeps the console output clean
@@ -652,6 +526,15 @@ describe('Select', () => {
       expect(screen.queryByRole('label')).toBeFalsy();
       expect(screen.getByLabelText(label)).toBeTruthy();
     });
+
+    const getFocusedOption = (container: HTMLElement) =>
+      container.querySelector('[class*="focused"]');
+
+    const expectFocusedOption = (con: HTMLElement, opt: MultiSelectOption) =>
+      expect(getFocusedOption(con)).toHaveTextContent(opt.label);
+
+    const expectSelectedValues = (values: string[]) =>
+      expect(getCombobox()).toHaveValue(values.toString());
   });
 });
 
@@ -670,3 +553,22 @@ const renderMultiSelect = (props?: Partial<MultiSelectProps>) =>
       {...props}
     />,
   );
+
+const getCombobox = () => screen.getByRole('combobox');
+
+const getOptions = () => screen.queryAllByRole('option');
+
+const expectItemToBeSelected = (item: HTMLElement) =>
+  expect(item).toHaveAttribute('aria-selected', 'true');
+
+const expectItemNotToBeSelected = (item: HTMLElement) =>
+  expect(item).toHaveAttribute('aria-selected', 'false');
+
+const expectSelectedOptions = (predicate: (index: number) => boolean) =>
+  getOptions().forEach((option, index) => {
+    predicate(index)
+      ? expectItemToBeSelected(option)
+      : expectItemNotToBeSelected(option);
+  });
+
+const getRoot = () => screen.getByTestId('select-root');

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -34,7 +34,7 @@ interface SelectPropsBase {
 }
 
 export interface SingleSelectOption {
-  displayName: string;
+  label: string;
   value: string;
 }
 
@@ -117,7 +117,7 @@ export const Select = (props: SelectProps) => {
 
   const findOptionFromValue = (v?: string) =>
     options.find((option) => option.value === v) ?? {
-      displayName: '',
+      label: '',
       value: '',
     };
 
@@ -267,10 +267,11 @@ export const Select = (props: SelectProps) => {
                 }
               }}
               role='combobox'
+              value={multiple ? selectedValues : activeOption}
             >
               {!multiple && (
                 <span className={classes['select--single__field__value']}>
-                  {findOptionFromValue(activeOption).displayName}
+                  {findOptionFromValue(activeOption).label}
                 </span>
               )}
               <span className={classes['select__field__arrow-wrapper']}>
@@ -284,6 +285,7 @@ export const Select = (props: SelectProps) => {
         isSearch={false}
         isValid={!error}
         label={label}
+        noFocusEffect={multiple}
         noPadding={true}
         readOnly={false}
       />
@@ -309,8 +311,9 @@ export const Select = (props: SelectProps) => {
             onMouseDown={(event) => event.preventDefault()}
             onKeyDown={(event) => event.preventDefault()}
             role='option'
+            value={option.value}
           >
-            {option.displayName}
+            {option.label}
           </li>
         ))}
       </ul>

--- a/src/components/_InputWrapper/InputWrapper.module.css
+++ b/src/components/_InputWrapper/InputWrapper.module.css
@@ -15,7 +15,7 @@
   border-color: var(--border-color);
 }
 
-.InputWrapper:focus-within {
+.InputWrapper--with-focus-effect:focus-within {
   outline: var(--outline-color) auto var(--border_width-thin);
   outline-offset: calc(var(--border_width-thin) + var(--border_width-standard));
 }

--- a/src/components/_InputWrapper/InputWrapper.test.tsx
+++ b/src/components/_InputWrapper/InputWrapper.test.tsx
@@ -149,6 +149,30 @@ describe('InputWrapper', () => {
         expect(textField.classList.contains(`InputWrapper--${v}`)).toBe(false);
       });
     });
+
+    it('Renders with padding class by default', () => {
+      render();
+      const { classList } = screen.getByTestId('InputWrapper');
+      expect(classList).toContain('InputWrapper--with-padding');
+    });
+
+    it('Renders without padding class when "noPadding" property is true', () => {
+      render({ noPadding: true });
+      const { classList } = screen.getByTestId('InputWrapper');
+      expect(classList).not.toContain('InputWrapper--with-padding');
+    });
+
+    it('Renders with focus-effect class by default', () => {
+      render();
+      const { classList } = screen.getByTestId('InputWrapper');
+      expect(classList).toContain('InputWrapper--with-focus-effect');
+    });
+
+    it('Renders without focus-effect class when "noFocusEffect" property is true', () => {
+      render({ noFocusEffect: true });
+      const { classList } = screen.getByTestId('InputWrapper');
+      expect(classList).not.toContain('InputWrapper--with-focus-effect');
+    });
   });
 
   describe('Label', () => {

--- a/src/components/_InputWrapper/InputWrapper.tsx
+++ b/src/components/_InputWrapper/InputWrapper.tsx
@@ -19,6 +19,7 @@ export interface InputWrapperProps {
   readOnly?: boolean | ReadOnlyVariant;
   isSearch?: boolean;
   label?: string;
+  noFocusEffect?: boolean;
   noPadding?: boolean;
   inputId?: string;
   inputRenderer: (props: InputRendererProps) => ReactNode;
@@ -32,6 +33,7 @@ export const InputWrapper = ({
   label,
   inputId,
   inputRenderer,
+  noFocusEffect,
   noPadding,
 }: InputWrapperProps) => {
   const randomInputId = useId();
@@ -62,6 +64,7 @@ export const InputWrapper = ({
           classes[`InputWrapper--${variant}`],
           {
             [classes[`InputWrapper--search`]]: isSearch,
+            [classes[`InputWrapper--with-focus-effect`]]: !noFocusEffect,
             [classes[`InputWrapper--with-padding`]]: !noPadding,
           },
         )}


### PR DESCRIPTION
## Description
- Changed `displayName` to `label` to keep naming consistent with the checkbox components (**breaking**)
- Added `value` attributes to relevant elements
- Improved focus styling (had to add a `noFocusEffect` property on `InputWrapper` since multiselect consists of several buttons and handles focus effects itself)
- Made tests look cleaner with regards to the 80 characters restriction

## Related Issue(s)
- #138

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
