### PR TITLE
Pass through table-props

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,3 +1,4 @@
+import type { HTMLProps } from 'react';
 import React from 'react';
 import cn from 'classnames';
 
@@ -5,7 +6,8 @@ import classes from './Table.module.css';
 import type { ChangeHandler } from './Context';
 import { TableContext } from './Context';
 
-export interface TableProps {
+export interface TableProps
+  extends Omit<HTMLProps<HTMLTableElement>, 'onChange'> {
   children?: React.ReactNode;
   selectRows?: boolean;
   onChange?: ChangeHandler;
@@ -17,9 +19,14 @@ export const Table = ({
   selectRows = false,
   onChange,
   selectedValue,
+  className,
+  ...tableProps
 }: TableProps) => {
   return (
-    <table className={cn(classes.Table)}>
+    <table
+      {...tableProps}
+      className={cn(classes.Table, className)}
+    >
       <TableContext.Provider value={{ selectRows, onChange, selectedValue }}>
         {children}
       </TableContext.Provider>

--- a/src/components/Table/TableBody.tsx
+++ b/src/components/Table/TableBody.tsx
@@ -1,18 +1,28 @@
+import type { HTMLProps } from 'react';
 import React from 'react';
 import cn from 'classnames';
 
 import classes from './TableBody.module.css';
 import { Variant, TableRowTypeContext } from './Context';
 
-export interface TableBodyProps {
+export interface TableBodyProps extends HTMLProps<HTMLTableSectionElement> {
   children?: React.ReactNode;
 }
 
-export const TableBody = ({ children }: TableBodyProps) => {
+export const TableBody = ({
+  children,
+  className,
+  ...tableBodyProps
+}: TableBodyProps) => {
   const variantStandard = Variant.Body;
   return (
     <TableRowTypeContext.Provider value={{ variantStandard }}>
-      <tbody className={cn(classes.TableBody)}>{children}</tbody>
+      <tbody
+        {...tableBodyProps}
+        className={cn(classes.TableBody, className)}
+      >
+        {children}
+      </tbody>
     </TableRowTypeContext.Provider>
   );
 };

--- a/src/components/Table/TableCell.tsx
+++ b/src/components/Table/TableCell.tsx
@@ -1,3 +1,4 @@
+import type { HTMLProps } from 'react';
 import React from 'react';
 import cn from 'classnames';
 
@@ -6,14 +7,10 @@ import type { SortHandler } from './Context';
 import { useTableRowTypeContext, Variant } from './Context';
 import { ReactComponent as SortIcon } from './sort_arrow.svg';
 
-export interface TableCellProps {
+export interface TableCellProps
+  extends Omit<HTMLProps<HTMLTableCellElement>, 'onChange'> {
   children?: React.ReactNode;
   variant?: string;
-  colSpan?: number;
-  type?: string;
-  src?: string;
-  alt?: string;
-  sortable?: boolean;
   onChange?: SortHandler;
   sortDirecton?: SortDirection;
   id?: string;
@@ -27,11 +24,12 @@ export enum SortDirection {
 
 export const TableCell = ({
   children,
-  colSpan = 1,
   variant,
   onChange,
   sortDirecton = SortDirection.NotSortable,
   id,
+  className,
+  ...tableCellProps
 }: TableCellProps) => {
   const { variantStandard } = useTableRowTypeContext();
 
@@ -49,8 +47,8 @@ export const TableCell = ({
         ? variantStandard === Variant.Header
         : variant === 'header') && (
         <th
-          className={cn(classes['header-table-cell'])}
-          colSpan={colSpan}
+          {...tableCellProps}
+          className={cn(classes['header-table-cell'], className)}
         >
           <div
             className={
@@ -88,15 +86,18 @@ export const TableCell = ({
         : variant === 'body') && (
         <>
           <td
-            className={cn(classes['body-table-cell'])}
-            colSpan={colSpan}
+            {...tableCellProps}
+            className={cn(classes['body-table-cell'], className)}
           >
             <div className={cn(classes['input'])}>{children}</div>
           </td>
         </>
       )}
       {variantStandard === Variant.Footer && (
-        <td colSpan={colSpan}>
+        <td
+          {...tableCellProps}
+          className={cn(className)}
+        >
           <div className={cn(classes['input'])}>{children}</div>
         </td>
       )}

--- a/src/components/Table/TableCell.tsx
+++ b/src/components/Table/TableCell.tsx
@@ -84,14 +84,12 @@ export const TableCell = ({
       {(variant == undefined
         ? variantStandard === Variant.Body
         : variant === 'body') && (
-        <>
-          <td
-            {...tableCellProps}
-            className={cn(classes['body-table-cell'], className)}
-          >
-            <div className={cn(classes['input'])}>{children}</div>
-          </td>
-        </>
+        <td
+          {...tableCellProps}
+          className={cn(classes['body-table-cell'], className)}
+        >
+          <div className={cn(classes['input'])}>{children}</div>
+        </td>
       )}
       {variantStandard === Variant.Footer && (
         <td

--- a/src/components/Table/TableFooter.tsx
+++ b/src/components/Table/TableFooter.tsx
@@ -1,18 +1,28 @@
+import type { HTMLProps } from 'react';
 import React from 'react';
 import cn from 'classnames';
 
 import classes from './TableFooter.module.css';
 import { Variant, TableRowTypeContext } from './Context';
 
-export interface TableFooterProps {
+export interface TableFooterProps extends HTMLProps<HTMLTableSectionElement> {
   children?: React.ReactNode;
 }
 
-export const TableFooter = ({ children }: TableFooterProps) => {
+export const TableFooter = ({
+  children,
+  className,
+  ...tableFooterProps
+}: TableFooterProps) => {
   const variantStandard = Variant.Footer;
   return (
     <TableRowTypeContext.Provider value={{ variantStandard }}>
-      <tfoot className={cn(classes['table-footer'])}>{children}</tfoot>
+      <tfoot
+        {...tableFooterProps}
+        className={cn(classes['table-footer'], className)}
+      >
+        {children}
+      </tfoot>
     </TableRowTypeContext.Provider>
   );
 };

--- a/src/components/Table/TableHeader.tsx
+++ b/src/components/Table/TableHeader.tsx
@@ -1,18 +1,28 @@
+import type { HTMLProps } from 'react';
 import React from 'react';
 import cn from 'classnames';
 
 import classes from './TableHeader.module.css';
 import { Variant, TableRowTypeContext } from './Context';
 
-export interface TableHeaderProps {
+export interface TableHeaderProps extends HTMLProps<HTMLTableSectionElement> {
   children?: React.ReactNode;
 }
 
-export const TableHeader = ({ children }: TableHeaderProps) => {
+export const TableHeader = ({
+  children,
+  className,
+  ...tableHeaderProps
+}: TableHeaderProps) => {
   const variantStandard = Variant.Header;
   return (
     <TableRowTypeContext.Provider value={{ variantStandard }}>
-      <thead className={cn(classes['table-header'])}>{children}</thead>
+      <thead
+        {...tableHeaderProps}
+        className={cn(classes['table-header'], className)}
+      >
+        {children}
+      </thead>
     </TableRowTypeContext.Provider>
   );
 };

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -1,3 +1,4 @@
+import type { HTMLProps } from 'react';
 import React from 'react';
 import cn from 'classnames';
 
@@ -9,7 +10,11 @@ import {
   Variant,
 } from './Context';
 
-export interface TableRowProps {
+export interface TableRowProps
+  extends Omit<
+    HTMLProps<HTMLTableRowElement>,
+    'onClick' | 'tabIndex' | 'onKeyUp'
+  > {
   children?: React.ReactNode;
   value?: string;
   selectSort?: string;
@@ -19,6 +24,8 @@ export const TableRow = ({
   children,
   value = 'no',
   selectSort = '',
+  className,
+  ...tableRowProps
 }: TableRowProps) => {
   const { variantStandard } = useTableRowTypeContext();
   const { onChange, selectedValue, selectRows } = useTableContext();
@@ -41,13 +48,18 @@ export const TableRow = ({
   return (
     <SortContext.Provider value={{ selectSort }}>
       <tr
-        className={cn(classes.TableRow, {
-          [classes['table-row--selected']]: value === selectedValue,
-          [classes['table-row--body']]:
-            variantStandard === Variant.Body &&
-            selectRows &&
-            value !== selectedValue,
-        })}
+        {...tableRowProps}
+        className={cn(
+          classes.TableRow,
+          {
+            [classes['table-row--selected']]: value === selectedValue,
+            [classes['table-row--body']]:
+              variantStandard === Variant.Body &&
+              selectRows &&
+              value !== selectedValue,
+          },
+          className,
+        )}
         onClick={handleClick}
         tabIndex={
           variantStandard === Variant.Body && selectRows ? 0 : undefined


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In order to make use of the new table-components it is nice to be able to control the props of the different html table-elements. This PR simply extends the components props with the relevant HTMLTableElement-props and passes these through. It also combines the classNames so that custom classes can be added as well.

There should not be any breaking changes from this.

## Related Issue(s)
- https://github.com/Altinn/app-frontend-react/issues/580

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- ~~Relevant automated test added (if you find this hard, leave it and we'll help out)~~
- ~~All tests run green~~

## Documentation
- ~~User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
