### PR TITLE
Make Select component more size adaptable

### DIFF
--- a/src/components/Select/Select.module.css
+++ b/src/components/Select/Select.module.css
@@ -33,10 +33,6 @@
     var(--field-height) - var(--component-input-border_width-default) * 2
   );
   --field-height: 36px;
-  --field-width-inside: calc(
-    var(--field-width) - var(--component-input-border_width-default) * 2
-  );
-  --field-width: 440px;
   --font_size: 16px;
   --interactive_element-cursor: pointer;
   --line-height: 1.5;
@@ -66,7 +62,7 @@
   --option_list-shadow: 1px 1px 3px #00000040;
   --option_list-z_index: 1;
   --option-outline-focus: none;
-  --option-padding_left: 12px;
+  --option-padding_horizontal: 12px;
   --singleselect_field-padding_left: 12px;
   --focus_visible-outline: 2px auto
     var(--interactive_components-colors-focus_outline);
@@ -96,6 +92,7 @@
   background: transparent;
   border: 0;
   cursor: var(--interactive_element-cursor);
+  height: 100%;
   margin: 0;
   padding: 0;
 }
@@ -110,8 +107,9 @@
   align-items: center;
   display: inline-flex;
   flex-direction: row;
+  font-family: var(--font_family-default);
+  font-size: var(--font_size);
   min-height: var(--field-height-inside);
-  min-width: var(--field-width);
   position: relative;
   width: 100%;
 }
@@ -143,9 +141,11 @@
     (var(--field-height-inside) - var(--arrow-height)) / 2 -
       var(--arrow_wrapper-margin)
   );
+  align-items: center;
   border-left: var(--arrow-border_left);
   box-sizing: border-box;
   display: flex;
+  height: calc(100% - var(--arrow-vertical_padding));
   margin-bottom: var(--arrow_wrapper-margin);
   margin-left: var(--arrow_wrapper-margin);
   margin-top: var(--arrow_wrapper-margin);
@@ -196,8 +196,8 @@
 }
 
 .select--multiple__field__delete-button__cross {
-  clip-path: var(--delete_cross-clip_path);
   background-color: var(--delete_cross-color);
+  clip-path: var(--delete_cross-clip_path);
   display: inline-block;
   height: var(--delete_cross-size);
   width: var(--delete_cross-size);
@@ -212,13 +212,12 @@
   display: flex;
   flex-direction: column;
   margin: 0;
-  padding: 0;
-  position: absolute;
-  width: var(--field-width);
   max-height: calc(
     var(--option-height) * var(--option_list-number_of_visible_options)
   );
   overflow-y: auto;
+  padding: 0;
+  position: absolute;
   z-index: var(--option_list-z_index);
 }
 
@@ -231,12 +230,15 @@
   cursor: var(--interactive_element-cursor);
   display: inline-block;
   min-height: var(--option-height);
-  padding-left: var(--option-padding_left);
+  overflow-x: hidden;
+  padding-left: var(--option-padding_horizontal);
+  padding-right: var(--option-padding_horizontal);
   padding-top: calc(
     (var(--option-height) - (var(--font_size) * var(--line-height))) / 2
   );
   text-align: left;
-  width: 100%;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .select__option-list__option:hover {

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -4,7 +4,12 @@ import { config } from 'storybook-addon-designs';
 
 import { StoryPage } from '@sb/StoryPage';
 
-import type { MultiSelectOption, SingleSelectOption } from './Select';
+import type {
+  MultiSelectOption,
+  MultiSelectProps,
+  SingleSelectOption,
+  SingleSelectProps,
+} from './Select';
 import { Select } from './Select';
 
 const figmaLink =
@@ -28,6 +33,19 @@ const multipleSelectOptions: MultiSelectOption[] = defaultOptions.map(
   (option) => ({ ...option, deleteButtonLabel: 'Slett ' + option.label }),
 );
 
+const defaultArgs: SingleSelectProps = {
+  label: 'Velg et fylke',
+  multiple: false,
+  options: defaultOptions,
+};
+
+const multipleSelectArgs: MultiSelectProps = {
+  deleteButtonLabel: 'Fjern alle',
+  label: 'Velg ett eller flere fylker',
+  multiple: true,
+  options: multipleSelectOptions,
+};
+
 export default {
   title: `Components/Select`,
   component: Select,
@@ -50,13 +68,14 @@ export default {
       ),
     },
   },
-  args: {
-    options: defaultOptions,
-    multiple: false,
-  },
+  args: defaultArgs,
 } as ComponentMeta<typeof Select>;
 
-const Template: ComponentStory<typeof Select> = (args) => <Select {...args} />;
+const Template: ComponentStory<typeof Select> = (args) => (
+  <div style={{ width: '440px' }}>
+    <Select {...args} />
+  </div>
+);
 
 export const Single = Template.bind({});
 Single.args = {};
@@ -92,7 +111,7 @@ SingleError.parameters = {
 };
 
 export const Multiple = Template.bind({});
-Multiple.args = { multiple: true, options: multipleSelectOptions };
+Multiple.args = multipleSelectArgs;
 Multiple.parameters = {
   docs: {
     description: {
@@ -103,7 +122,7 @@ Multiple.parameters = {
 };
 
 export const MultipleDisabled = Template.bind({});
-MultipleDisabled.args = { disabled: true };
+MultipleDisabled.args = { ...multipleSelectArgs, disabled: true };
 MultipleDisabled.parameters = {
   docs: {
     description: {
@@ -114,7 +133,7 @@ MultipleDisabled.parameters = {
 };
 
 export const MultipleError = Template.bind({});
-MultipleError.args = { error: true };
+MultipleError.args = { ...multipleSelectArgs, error: true };
 MultipleError.parameters = {
   docs: {
     description: {

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
 import cn from 'classnames';
+import tokens from '@altinn/figma-design-tokens/dist/tokens.json';
 
 import { InputWrapper } from '@/components/_InputWrapper';
 import { MultiSelectItem } from '@/components/Select/MultiSelectItem';
@@ -90,6 +91,7 @@ export const Select = (props: SelectProps) => {
   const [expanded, setExpanded] = useState<boolean>(false);
 
   const listboxRef = useRef<HTMLUListElement>(null);
+  const selectFieldRef = useRef<HTMLSpanElement>(null);
 
   useEffect(() => {
     // Ensure that active option is always visible when using keyboard
@@ -206,6 +208,10 @@ export const Select = (props: SelectProps) => {
 
   const listboxId = useId();
 
+  const width = selectFieldRef.current
+    ? `calc(${selectFieldRef.current.offsetWidth}px + 2 * ${tokens.component.input.border_width.default.value})`
+    : undefined;
+
   return (
     <div
       className={cn(
@@ -221,7 +227,10 @@ export const Select = (props: SelectProps) => {
         disabled={disabled}
         inputId={inputId}
         inputRenderer={({ className, inputId }) => (
-          <span className={cn(className, classes['select__field'])}>
+          <span
+            className={cn(className, classes['select__field'])}
+            ref={selectFieldRef}
+          >
             {multiple && (
               <>
                 <span className={classes['select--multiple__field__values']}>
@@ -254,7 +263,7 @@ export const Select = (props: SelectProps) => {
             <button
               aria-controls={listboxId}
               aria-expanded={expanded}
-              aria-label={hideLabel ? label : undefined}
+              aria-label={label}
               className={classes['select__field__button']}
               disabled={disabled}
               id={inputId}
@@ -294,6 +303,7 @@ export const Select = (props: SelectProps) => {
         id={listboxId}
         ref={listboxRef}
         role='listbox'
+        style={{ width }}
       >
         {options.map((option) => (
           <li


### PR DESCRIPTION
## Description
Made the Select component adapt more nicely to containers of different size and set the width of the expandable list to always follow the width of the field.

## Related Issue(s)
- #138 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
