### PR TITLE
Button component: merge provided className

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -71,12 +71,14 @@ const Button = (
     iconName,
     svgIconComponent,
     type = 'button',
+    className,
     ...restHTMLProps
   }: PropsWithChildren<ButtonProps>,
   ref?: React.Ref<HTMLButtonElement> | undefined,
 ) => {
   return (
     <button
+      {...restHTMLProps}
       ref={ref}
       className={cn(
         classes.button,
@@ -87,9 +89,9 @@ const Button = (
         { [classes['button--full-width']]: fullWidth },
         { [classes['button--dashed-border']]: dashedBorder },
         { [classes[`button--only-icon`]]: !children && iconName },
+        className,
       )}
       type={type}
-      {...restHTMLProps}
     >
       {(iconPlacement === 'left' || !children) &&
         renderIcon(iconName, svgIconComponent)}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Quick fix that merges className from props into button's classNames. Previously providing a custom className would override all styling since the restProps were inserted last.

## Related Issue(s)
- https://github.com/Altinn/app-frontend-react/issues/580

