### PR TITLE
Fix labelling issues

### DIFF
--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -208,7 +208,7 @@ describe('Select', () => {
     it('Hides label, but makes it accessible, if the "hideLabel" property is set', async () => {
       const label = 'Lorem ipsum';
       renderSingleSelect({ hideLabel: true, label });
-      expect(screen.queryByRole('label')).toBeFalsy();
+      expect(screen.queryByText(label)).toBeFalsy();
       expect(screen.getByLabelText(label)).toBeTruthy();
     });
 
@@ -523,7 +523,7 @@ describe('Select', () => {
     it('Hides label, but makes it accessible, if the "hideLabel" property is set', async () => {
       const label = 'Lorem ipsum';
       renderMultiSelect({ hideLabel: true, label });
-      expect(screen.queryByRole('label')).toBeFalsy();
+      expect(screen.queryByText(label)).toBeFalsy();
       expect(screen.getByLabelText(label)).toBeTruthy();
     });
 

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -293,7 +293,7 @@ export const Select = (props: SelectProps) => {
         )}
         isSearch={false}
         isValid={!error}
-        label={label}
+        label={hideLabel ? undefined : label}
         noFocusEffect={multiple}
         noPadding={true}
         readOnly={false}

--- a/src/components/TextField/TextField.test.tsx
+++ b/src/components/TextField/TextField.test.tsx
@@ -14,53 +14,68 @@ import { TextField } from './TextField';
 const user = userEvent.setup();
 
 describe('TextField', () => {
-  it('should trigger onPaste when pasting into input', () => {
-    const handlePaste = jest.fn();
-    render({
-      onPaste: handlePaste,
+  describe('Default', () => {
+    it('should trigger onPaste when pasting into input', () => {
+      const handlePaste = jest.fn();
+      render({
+        onPaste: handlePaste,
+      });
+
+      const element = screen.getByRole('textbox');
+      const paste = createEvent.paste(element, {
+        clipboardData: {
+          getData: () => 'hello world',
+        },
+      });
+
+      fireEvent(element, paste);
+
+      expect(handlePaste).toHaveBeenCalledTimes(1);
     });
 
-    const element = screen.getByRole('textbox');
-    const paste = createEvent.paste(element, {
-      clipboardData: {
-        getData: () => 'hello world',
-      },
+    it('should trigger onBlur event when field loses focus', async () => {
+      const handleChange = jest.fn();
+      render({ onBlur: handleChange });
+
+      const element = screen.getByRole('textbox');
+      await user.click(element);
+      expect(element).toHaveFocus();
+      await user.tab();
+
+      expect(handleChange).toHaveBeenCalledTimes(1);
     });
 
-    fireEvent(element, paste);
+    it('should trigger onChange event for each keystroke', async () => {
+      const handleChange = jest.fn();
+      render({ onChange: handleChange });
 
-    expect(handlePaste).toHaveBeenCalledTimes(1);
-  });
+      const element = screen.getByRole('textbox');
+      await user.click(element);
+      expect(element).toHaveFocus();
+      await user.keyboard('test');
 
-  it('should trigger onBlur event when field loses focus', async () => {
-    const handleChange = jest.fn();
-    render({ onBlur: handleChange });
+      expect(handleChange).toHaveBeenCalledTimes(4);
+    });
 
-    const element = screen.getByRole('textbox');
-    await user.click(element);
-    expect(element).toHaveFocus();
-    await user.tab();
+    it('Sets given id on input field', () => {
+      const id = 'some-unique-id';
+      render({ id });
+      expect(screen.getByRole('textbox')).toHaveAttribute('id', id);
+    });
 
-    expect(handleChange).toHaveBeenCalledTimes(1);
-  });
+    it('Focuses on input field when label is clicked and id is not given', async () => {
+      const label = 'Lorem ipsum';
+      render({ label });
+      await user.click(screen.getByText(label));
+      expect(screen.getByRole('textbox')).toHaveFocus();
+    });
 
-  it('should trigger onChange event for each keystroke', async () => {
-    const handleChange = jest.fn();
-    render({ onChange: handleChange });
-
-    const element = screen.getByRole('textbox');
-    await user.click(element);
-    expect(element).toHaveFocus();
-    await user.keyboard('test');
-
-    expect(handleChange).toHaveBeenCalledTimes(4);
-  });
-
-  it('Focuses on input field when label is clicked', async () => {
-    const label = 'Lorem ipsum';
-    render({ label });
-    await user.click(screen.getByText(label));
-    expect(screen.getByRole('textbox')).toHaveFocus();
+    it('Focuses on input field when label is clicked and id is given', async () => {
+      const label = 'Lorem ipsum';
+      render({ id: 'some-unique-id', label });
+      await user.click(screen.getByText(label));
+      expect(screen.getByRole('textbox')).toHaveFocus();
+    });
   });
 
   describe('number-format-input', () => {
@@ -84,10 +99,8 @@ describe('TextField', () => {
     });
 
     it('should render as a NumberFormat element if format.number is specified', () => {
-      render({ isValid: true, formatting: { number: { prefix: '$' } } });
-      expect(
-        screen.getByTestId('id-formatted-number-default'),
-      ).toBeInTheDocument();
+      render({ isValid: true, formatting: { number: {} } });
+      expect(screen.getByRole('textbox').inputMode).toBe('numeric');
     });
 
     it('should trigger onBlur event when field loses focus', async () => {
@@ -285,12 +298,31 @@ describe('TextField', () => {
       expect(handleChange).toHaveBeenCalledTimes(2);
       expect(testValue).toBe('1258');
     });
+
+    it('Sets given id on input field', () => {
+      const id = 'some-unique-id';
+      render({ id, formatting: { number: {} } });
+      expect(screen.getByRole('textbox')).toHaveAttribute('id', id);
+    });
+
+    it('Focuses on input field when label is clicked and id is not given', async () => {
+      const label = 'Lorem ipsum';
+      render({ label, formatting: { number: {} } });
+      await user.click(screen.getByText(label));
+      expect(screen.getByRole('textbox')).toHaveFocus();
+    });
+
+    it('Focuses on input field when label is clicked and id is given', async () => {
+      const label = 'Lorem ipsum';
+      render({ id: 'some-unique-id', label, formatting: { number: {} } });
+      await user.click(screen.getByText(label));
+      expect(screen.getByRole('textbox')).toHaveFocus();
+    });
   });
 });
 
 const render = (props: Partial<TextFieldProps> = {}) => {
   const allProps = {
-    id: 'id',
     onChange: jest.fn(),
     ...props,
   } as TextFieldProps;

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -111,9 +111,9 @@ export const TextField = ({
       readOnly={readOnly}
       label={label}
       inputId={id}
-      inputRenderer={({ className, variant }) => {
+      inputRenderer={({ className, variant, inputId }) => {
         const commonProps = {
-          id,
+          id: inputId,
           readOnly: Boolean(readOnly),
           disabled,
           required,
@@ -135,7 +135,7 @@ export const TextField = ({
               {...commonProps}
               {...formatting.number}
               {...rest}
-              data-testid={`${id}-formatted-number-${variant}`}
+              data-testid={`${inputId}-formatted-number-${variant}`}
               onValueChange={handleNumberFormatChange}
               valueIsNumericString={true}
               onKeyDown={(e) =>
@@ -153,7 +153,7 @@ export const TextField = ({
               {...commonProps}
               {...formatting.number}
               {...rest}
-              data-testid={`${id}-formatted-number-${variant}`}
+              data-testid={`${inputId}-formatted-number-${variant}`}
               onValueChange={handleNumberFormatChange}
               valueIsNumericString={true}
             />
@@ -163,7 +163,7 @@ export const TextField = ({
             <input
               {...commonProps}
               {...rest}
-              data-testid={`${id}-${variant}`}
+              data-testid={`${inputId}-${variant}`}
               onChange={onChange}
             />
           );


### PR DESCRIPTION
## Description
- Ensure that the input field in `TextField` always has an ID (for labelling purposes) by using the `inputId` argument from `InputWrapper`, and add related tests.
- Group tests related to the default mode for TextField in their own `describe` block.
- Fix `hideLabel` functionality on `Select` and related test that gave a false positive.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
