### PR TITLE
--breaking-change-- remove iconName prop along with functionality

### DIFF
--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render as renderRtl, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { Success as SuccessIcon } from '@navikt/ds-icons';
 
 import type { ButtonProps } from './Button';
 
@@ -66,7 +67,7 @@ describe('Button', () => {
   });
 
   it('should render an icon on the left side of text when given an existing iconName and no iconPlacement', () => {
-    render({ iconName: 'Add', children: 'Button text' });
+    render({ icon: <SuccessIcon />, children: 'Button text' });
     const icon = screen.getByRole('img');
     expect(
       screen.getByRole('button', {
@@ -77,7 +78,7 @@ describe('Button', () => {
 
   it('should render an icon on the right side of text when given an existing iconName and iconPlacement is right', () => {
     render({
-      iconName: 'Add',
+      icon: <SuccessIcon />,
       iconPlacement: 'right',
       children: 'Button text',
     });

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -6,7 +6,6 @@ import React, {
 import cn from 'classnames';
 
 import { SvgIcon } from '../SvgIcon';
-import type { IconConditionalProps, IconKey } from '../SvgIcon/SvgIcon';
 
 import classes from './Button.module.css';
 
@@ -30,34 +29,15 @@ export enum ButtonVariant {
   Quiet = 'quiet',
 }
 
-interface ButtonCommonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;
   color?: ButtonColor;
   size?: ButtonSize;
   fullWidth?: boolean;
   dashedBorder?: boolean;
+  icon?: React.ReactNode;
   iconPlacement?: 'right' | 'left';
 }
-
-export type ButtonProps = ButtonCommonProps & IconConditionalProps;
-
-const renderIcon = (iconName?: string, iconComponent?: JSX.Element) => {
-  if (iconName && !iconComponent) {
-    return (
-      <SvgIcon
-        iconName={iconName as IconKey}
-        className={cn(classes[`icon`])}
-      />
-    );
-  } else if (!iconName && iconComponent) {
-    return (
-      <SvgIcon
-        svgIconComponent={iconComponent}
-        className={cn(classes[`icon`])}
-      />
-    );
-  }
-};
 
 const Button = (
   {
@@ -68,8 +48,7 @@ const Button = (
     fullWidth = false,
     dashedBorder = false,
     iconPlacement = 'left',
-    iconName,
-    svgIconComponent,
+    icon,
     type = 'button',
     className,
     ...restHTMLProps
@@ -88,15 +67,24 @@ const Button = (
         classes[`button--${variant}--${color}`],
         { [classes['button--full-width']]: fullWidth },
         { [classes['button--dashed-border']]: dashedBorder },
-        { [classes[`button--only-icon`]]: !children && iconName },
+        { [classes[`button--only-icon`]]: !children && icon },
         className,
       )}
       type={type}
     >
-      {(iconPlacement === 'left' || !children) &&
-        renderIcon(iconName, svgIconComponent)}
+      {icon && iconPlacement === 'left' && (
+        <SvgIcon
+          svgIconComponent={icon}
+          className={classes.icon}
+        />
+      )}
       {children}
-      {iconPlacement === 'right' && renderIcon(iconName, svgIconComponent)}
+      {icon && iconPlacement === 'right' && (
+        <SvgIcon
+          svgIconComponent={icon}
+          className={classes.icon}
+        />
+      )}
     </button>
   );
 };

--- a/src/components/Button/Stories/FilledButton.stories.tsx
+++ b/src/components/Button/Stories/FilledButton.stories.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import type { ComponentStory, ComponentMeta } from '@storybook/react';
 import { config } from 'storybook-addon-designs';
+import { Success as SuccessIcon } from '@navikt/ds-icons';
 
 import { StoryPage } from '@sb/StoryPage';
 
 import { Button, ButtonVariant, ButtonColor } from '..';
 
-import { ReactComponent as SuccessIcon } from './success.svg';
+import { ReactComponent as SuccessIconCustom } from './success.svg';
 
 const figmaLink =
   'https://www.figma.com/file/vpM9dqqQPHqU6ogfKp5tlr/DDS---Core-Components?node-id=6691%3A30098';
@@ -112,7 +113,7 @@ Danger.parameters = {
 export const SuccessWithIcon = Template.bind({});
 SuccessWithIcon.args = {
   color: ButtonColor.Success,
-  iconName: 'Success',
+  icon: <SuccessIcon />,
   iconPlacement: 'left',
   children: 'Button',
 };
@@ -127,7 +128,7 @@ SuccessWithIcon.parameters = {
 export const SuccessWithCustomIcon = Template.bind({});
 SuccessWithCustomIcon.args = {
   color: ButtonColor.Success,
-  svgIconComponent: <SuccessIcon />,
+  icon: <SuccessIconCustom />,
   iconPlacement: 'left',
   children: 'Button',
 };
@@ -142,7 +143,7 @@ SuccessWithCustomIcon.parameters = {
 export const SecondaryWithIconNoText = Template.bind({});
 SecondaryWithIconNoText.args = {
   color: ButtonColor.Secondary,
-  iconName: 'Close',
+  icon: <SuccessIcon />,
 };
 SecondaryWithIconNoText.parameters = {
   docs: {
@@ -155,7 +156,7 @@ SecondaryWithIconNoText.parameters = {
 export const FullWidth = WithinContainerTemplate.bind({});
 FullWidth.args = {
   color: ButtonColor.Primary,
-  iconName: 'AddCircle',
+  icon: <SuccessIcon />,
   fullWidth: true,
   children: `Secondary button`,
 };

--- a/src/components/Button/Stories/OutlineButton.stories.tsx
+++ b/src/components/Button/Stories/OutlineButton.stories.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import type { ComponentStory, ComponentMeta } from '@storybook/react';
 import { config } from 'storybook-addon-designs';
+import { Success as SuccessIcon } from '@navikt/ds-icons';
 
 import { StoryPage } from '@sb/StoryPage';
 
 import { Button, ButtonVariant, ButtonColor } from '..';
 
-import { ReactComponent as SuccessIcon } from './success.svg';
+import { ReactComponent as SuccessIconCustom } from './success.svg';
 
 const figmaLink =
   'https://www.figma.com/file/vpM9dqqQPHqU6ogfKp5tlr/DDS---Core-Components?node-id=6691%3A30487';
@@ -109,10 +110,10 @@ Danger.parameters = {
   },
 };
 
-export const SuccessWithIcon = WithinContainerTemplate.bind({});
+export const SuccessWithIcon = Template.bind({});
 SuccessWithIcon.args = {
   color: ButtonColor.Success,
-  iconName: 'Success',
+  icon: <SuccessIcon />,
   iconPlacement: 'left',
   children: 'Button',
 };
@@ -127,7 +128,7 @@ SuccessWithIcon.parameters = {
 export const SuccessWithCustomIcon = Template.bind({});
 SuccessWithCustomIcon.args = {
   color: ButtonColor.Success,
-  svgIconComponent: <SuccessIcon />,
+  icon: <SuccessIconCustom />,
   iconPlacement: 'left',
   children: 'Button',
 };
@@ -142,7 +143,7 @@ SuccessWithCustomIcon.parameters = {
 export const SecondaryWithIconNoText = Template.bind({});
 SecondaryWithIconNoText.args = {
   color: ButtonColor.Secondary,
-  iconName: 'Close',
+  icon: <SuccessIcon />,
 };
 SecondaryWithIconNoText.parameters = {
   docs: {
@@ -155,7 +156,7 @@ SecondaryWithIconNoText.parameters = {
 export const FullWidthAndDashedBorder = WithinContainerTemplate.bind({});
 FullWidthAndDashedBorder.args = {
   color: ButtonColor.Primary,
-  iconName: 'AddCircle',
+  icon: <SuccessIcon />,
   fullWidth: true,
   dashedBorder: true,
   children: `Secondary button`,

--- a/src/components/Button/Stories/QuietButton.stories.tsx
+++ b/src/components/Button/Stories/QuietButton.stories.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import type { ComponentStory, ComponentMeta } from '@storybook/react';
 import { config } from 'storybook-addon-designs';
+import { Success as SuccessIcon } from '@navikt/ds-icons';
 
 import { StoryPage } from '@sb/StoryPage';
 
 import { Button, ButtonVariant, ButtonColor, ButtonSize } from '..';
 
-import { ReactComponent as SuccessIcon } from './success.svg';
+import { ReactComponent as SuccessIconCustom } from './success.svg';
 
 const figmaLink =
   'https://www.figma.com/file/vpM9dqqQPHqU6ogfKp5tlr/DDS---Core-Components?node-id=6691%3A31509';
@@ -113,7 +114,7 @@ Danger.parameters = {
 export const SuccessWithIcon = Template.bind({});
 SuccessWithIcon.args = {
   color: ButtonColor.Success,
-  iconName: 'Success',
+  icon: <SuccessIcon />,
   iconPlacement: 'left',
   children: 'Button',
 };
@@ -128,7 +129,7 @@ SuccessWithIcon.parameters = {
 export const SuccessWithCustomIcon = Template.bind({});
 SuccessWithCustomIcon.args = {
   color: ButtonColor.Success,
-  svgIconComponent: <SuccessIcon />,
+  icon: <SuccessIconCustom />,
   iconPlacement: 'left',
   children: 'Button',
 };
@@ -143,7 +144,7 @@ SuccessWithCustomIcon.parameters = {
 export const SuccessWithIconNoText = Template.bind({});
 SuccessWithIconNoText.args = {
   color: ButtonColor.Success,
-  iconName: 'Success',
+  icon: <SuccessIcon />,
 };
 SuccessWithIconNoText.parameters = {
   docs: {
@@ -156,9 +157,10 @@ SuccessWithIconNoText.parameters = {
 export const FullWidth = WithinContainerTemplate.bind({});
 FullWidth.args = {
   color: ButtonColor.Primary,
-  iconName: 'AddCircle',
+  icon: <SuccessIcon />,
   fullWidth: true,
   children: `Secondary button`,
+  iconPlacement: 'left',
 };
 FullWidth.parameters = {
   docs: {

--- a/src/components/SvgIcon/Stories/SvgIcon.stories.tsx
+++ b/src/components/SvgIcon/Stories/SvgIcon.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { ComponentStory, ComponentMeta } from '@storybook/react';
 import { config } from 'storybook-addon-designs';
+import { Success as SuccessIconNAV } from '@navikt/ds-icons';
 
 import { StoryPage } from '@sb/StoryPage';
 
@@ -41,12 +42,12 @@ const Template: ComponentStory<typeof SvgIcon> = (args) => (
 
 export const IconFromNavIconLibrary = Template.bind({});
 IconFromNavIconLibrary.args = {
-  iconName: 'Success',
+  svgIconComponent: <SuccessIconNAV />,
 };
 IconFromNavIconLibrary.parameters = {
   docs: {
     description: {
-      story: "`<SvgIcon iconName='Success' />`",
+      story: '`<SvgIcon svgIconComponent: <SuccessIconNAV />`',
     },
   },
 };

--- a/src/components/SvgIcon/SvgIcon.test.tsx
+++ b/src/components/SvgIcon/SvgIcon.test.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { Success as SuccessIcon } from '@navikt/ds-icons';
 
 import { ReactComponent as MockIcon } from './Stories/success.svg';
 import { SvgIcon } from './SvgIcon';
 
 describe('SvgIcon', () => {
-  it('should render an icon when given a name of an icon in NAVs icon library', () => {
-    render(<SvgIcon iconName={'Add'} />);
+  it('should render an icon when given an icon in NAVs icon library', () => {
+    render(<SvgIcon svgIconComponent={<SuccessIcon />} />);
     expect(screen.getByRole('img')).toBeInTheDocument();
   });
   it('should render an icon when given a svg imported as a react component', () => {

--- a/src/components/SvgIcon/SvgIcon.tsx
+++ b/src/components/SvgIcon/SvgIcon.tsx
@@ -1,33 +1,15 @@
 import type { SVGAttributes } from 'react';
-import React, { cloneElement } from 'react';
-import * as Icons from '@navikt/ds-icons';
+import { isValidElement, cloneElement } from 'react';
+import type React from 'react';
 
-export type IconKey = keyof typeof Icons;
+export type IconComponentProps = {
+  svgIconComponent: React.ReactNode;
+};
 
-export type IconConditionalProps =
-  | {
-      iconName?: IconKey;
-      svgIconComponent?: never;
-    }
-  | {
-      iconName?: never;
-      svgIconComponent?: JSX.Element;
-    };
+export type SvgIconProps = IconComponentProps & SVGAttributes<SVGElement>;
 
-export type SvgIconProps = IconConditionalProps & SVGAttributes<SVGElement>;
-
-export const SvgIcon = ({
-  iconName,
-  svgIconComponent,
-  ...rest
-}: SvgIconProps) => {
-  if (iconName) {
-    // eslint-disable-next-line import/namespace
-    const ImportedIcon = Icons[iconName];
-    if (ImportedIcon) {
-      return <ImportedIcon {...rest} />;
-    }
-  } else if (svgIconComponent) {
+export const SvgIcon = ({ svgIconComponent, ...rest }: SvgIconProps) => {
+  if (isValidElement(svgIconComponent)) {
     return cloneElement(svgIconComponent, { ...rest });
   }
   return null;


### PR DESCRIPTION
Remove iconName property which allowed for inserting an icon with setting iconName to a name of an icon existing in NAV's icon library. The implementation did not allow for treeshaking and added a lot of extra unused data to the bundle as every single icon was added regardless if used or not. 

The way of using Icons with the button is now to import an icon from navikt/ds-icons and pass it to the buttons `icon` property.

```
import { Success as SuccessIcon } from '@navikt/ds-icons';
<Button icon={<SuccessIcon />} />
```

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
