### PR TITLE
Add tabs component

### DIFF
--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -4,7 +4,8 @@ import cn from 'classnames';
 import { Checkbox, FieldSet } from '@/components';
 import type { CheckboxProps } from '@/components/Checkbox/Checkbox';
 import { FieldSetSize } from '@/components/FieldSet/FieldSet';
-import { arraysEqual } from '@/utils/arrayUtils';
+import { areItemsUnique, arraysEqual } from '@/utils/arrayUtils';
+import { useUpdate } from '@/hooks';
 
 import classes from './CheckboxGroup.module.css';
 
@@ -59,8 +60,7 @@ export const CheckboxGroup = ({
   onChange,
   variant = CheckboxGroupVariant.Vertical,
 }: CheckboxGroupProps) => {
-  const allNames = items.map((item) => item.name);
-  if (allNames.length !== new Set(allNames).size) {
+  if (!areItemsUnique(items.map((item) => item.name))) {
     throw Error('Each name in the checkbox group must be unique.');
   }
 
@@ -71,13 +71,10 @@ export const CheckboxGroup = ({
     [items],
   );
 
-  const firstRender = useRef(true);
   const prevCheckedNames = useRef(checkedNames);
 
-  useEffect(() => {
-    if (firstRender.current) {
-      firstRender.current = false;
-    } else if (
+  useUpdate(() => {
+    if (
       onChange &&
       !disabled &&
       !arraysEqual(prevCheckedNames.current, checkedNames)

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -4,8 +4,7 @@ import tokens from '@altinn/figma-design-tokens/dist/tokens.json';
 
 import { InputWrapper } from '@/components/_InputWrapper';
 import { MultiSelectItem } from '@/components/Select/MultiSelectItem';
-import { useKeyboardEventListener } from '@/hooks/useKeyboardEventListener';
-import { useEventListener } from '@/hooks/useEventListener';
+import { useEventListener, useKeyboardEventListener } from '@/hooks';
 
 import classes from './Select.module.css';
 

--- a/src/components/Tabs/Tabs.module.css
+++ b/src/components/Tabs/Tabs.module.css
@@ -1,0 +1,73 @@
+.tabs {
+  --divider-color: #c9c9c9;
+  --divider-width: 1px;
+  --tab-border_bottom_color-selected: var(--colors-blue-700);
+  --tab-border_bottom_color: transparent;
+  --tab-border_bottom_width: 4px;
+  --tab-font_family: var(--font_family-default);
+  --tab-font_size: var(--font_size-component-size-sm);
+  --tab-font_weight: 500;
+  --tab-height: 32px;
+  --tab-text_color-hover: var(--colors-black);
+  --tab-text_color-selected: var(--colors-blue-700);
+  --tab-text_color: #68707c;
+  --tablist-gap: 36px;
+  --tablist-margin_horizontal: 2rem;
+  --tabpanel-margin_horizontal: 2rem;
+  --tabpanel-margin_vertical: 2rem;
+  position: relative;
+}
+
+.tabs__tablist {
+  display: flex;
+  gap: var(--tablist-gap);
+  margin: 0 var(--tablist-margin_horizontal);
+}
+
+.tabs__tablist__tab {
+  background-color: transparent;
+  border-bottom-color: var(--tab-border_bottom_color);
+  border-bottom-style: solid;
+  border-width: 0 0 var(--tab-border_bottom_width) 0;
+  color: var(--tab-text_color);
+  cursor: pointer;
+  font-family: var(--tab-font_family);
+  font-size: var(--tab-font_size);
+  font-weight: var(--tab-font_weight);
+  line-height: var(--tab-height);
+  margin: 0;
+  overflow: hidden;
+  padding: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tabs__tablist__tab--selected {
+  --tab-text_color: var(--tab-text_color-selected);
+  --tab-border_bottom_color: var(--tab-border_bottom_color-selected);
+}
+
+.tabs__tablist__tab:hover {
+  --tab-text_color: var(--tab-text_color-hover);
+}
+
+.tabs__tablist__tab:focus-visible {
+  outline: var(--component-input-color-outline-focus) auto 2px;
+  outline-offset: 2px;
+}
+
+.tabs__divider {
+  border-color: var(--divider-color);
+  border-style: solid;
+  border-width: var(--divider-width) 0 0 0;
+  height: var(--divider-width);
+  margin: 0;
+  position: absolute;
+  top: var(--tab-height);
+  width: 100%;
+  z-index: -1;
+}
+
+.tabs__tabpanel {
+  margin: var(--tabpanel-margin_vertical) var(--tabpanel-margin_horizontal);
+}

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import type { ComponentStory, ComponentMeta } from '@storybook/react';
+import { config } from 'storybook-addon-designs';
+
+import { StoryPage } from '@sb/StoryPage';
+
+import { Tabs } from './Tabs';
+
+const figmaLink =
+  'https://www.figma.com/file/vpM9dqqQPHqU6ogfKp5tlr/DDS---Core-Components?node-id=9551%3A54208&t=hWPz7o59Op8wlvoS-0';
+
+export default {
+  title: `Components/Tabs`,
+  component: Tabs,
+  parameters: {
+    design: config([
+      {
+        type: 'figma',
+        url: figmaLink,
+      },
+      {
+        type: 'link',
+        url: figmaLink,
+      },
+    ]),
+    docs: {
+      page: () => (
+        <StoryPage
+          description={`This component allows the user to tab between several panels.
+                        It is useful to give a structured view of elements that do not have to be visible all at the same time.
+                        Tabs are selected using the mouse or by keyboard navigation. On the keyboard, left and right arrow keys are used to switch focus and the enter or space keys are used to open the focused tab.
+                        The component accepts a list of \`TabItem\`s (\`item\` property) consisting of a tab name and some tab panel content.
+                        It is also possible to specify IDs for the tab and the panel components (they will be generated if not given).
+                        The \`activeTab\` property can be used to define which tab should be selected by default. It defaults to the first tab.
+                        The \`onChange\` property optional and can be used to trigger some function the user switches to another tab. It is called with the tab name as a parameter.`}
+        />
+      ),
+    },
+  },
+  args: {
+    items: [
+      {
+        name: 'Ild',
+        content: (
+          <p>
+            Nulla nec rutrum libero. Curabitur lorem est, tempor nec iaculis in,
+            egestas eu lacus. Ut malesuada risus ut ipsum consequat mattis.
+            Donec quis nunc ut lorem suscipit pharetra. Nulla ornare sed nisl
+            nec facilisis. Sed in lacinia elit. Sed et eleifend nisi. Sed
+            egestas nulla lobortis sapien scelerisque, at venenatis risus
+            elementum. Aliquam eleifend, metus non molestie viverra, erat sem
+            ornare enim, nec suscipit nulla nisi vel dolor. Etiam volutpat
+            sapien arcu. Orci varius natoque penatibus et magnis dis parturient
+            montes, nascetur ridiculus mus. Nulla sollicitudin molestie leo sit
+            amet faucibus. Sed interdum condimentum interdum. Praesent volutpat
+            turpis mattis purus venenatis egestas. In iaculis condimentum
+            fringilla. Duis dignissim turpis mattis tristique vulputate.
+          </p>
+        ),
+      },
+      {
+        name: 'Jord',
+        content: (
+          <p>
+            Vestibulum nisl diam, tempus sit amet justo eu, semper facilisis
+            dolor. Proin scelerisque tellus sit amet consectetur condimentum.
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque et
+            dui vehicula, semper arcu vitae, posuere odio. Pellentesque eu ante
+            in elit semper pellentesque. Donec cursus eros non diam condimentum
+            viverra. Pellentesque at odio lorem. Aenean ac enim et risus
+            bibendum scelerisque et a purus. Donec ultricies, ex et ornare
+            fringilla, turpis ex consectetur ante, ut porta libero metus quis
+            magna. Nulla eu hendrerit ex, non dapibus quam. Nulla dictum ligula
+            tellus, et elementum orci convallis sit amet. Class aptent taciti
+            sociosqu ad litora torquent per conubia nostra, per inceptos
+            himenaeos. Fusce dolor orci, sagittis vel elit eget, viverra
+            ultrices nulla.
+          </p>
+        ),
+      },
+      {
+        name: 'Luft',
+        content: (
+          <p>
+            Integer dictum lacus vitae urna lobortis, scelerisque varius metus
+            maximus. Integer ornare pharetra metus, vel mattis urna. Interdum et
+            malesuada fames ac ante ipsum primis in faucibus. Nulla consectetur
+            ipsum ac magna sollicitudin, ac fermentum sem tempus. Proin rutrum
+            aliquam eros eu accumsan. Duis rhoncus urna a tellus sagittis, eu
+            aliquam dui pharetra. Praesent eu libero consectetur, varius urna
+            quis, volutpat magna. Vivamus ornare magna at vehicula pulvinar.
+            Curabitur risus lorem, placerat sit amet mollis venenatis, placerat
+            sed ligula. Donec pellentesque quis est nec viverra. Sed ultricies
+            aliquam nunc, sit amet faucibus augue tempor quis. Pellentesque
+            porttitor sapien quis risus placerat, in facilisis augue molestie.
+          </p>
+        ),
+      },
+      {
+        name: 'Vann',
+        content: (
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean vel
+            leo nibh. Fusce neque nulla, semper quis rutrum eu, volutpat nec
+            mauris. In lacinia iaculis venenatis. Aliquam pulvinar lectus lorem,
+            a congue nulla dictum vel. Donec augue eros, cursus ut porta eu,
+            mollis sodales odio. Vestibulum rutrum sollicitudin nisi, sed
+            facilisis nibh dictum at. Nulla arcu mi, iaculis quis luctus at,
+            vulputate hendrerit quam. Suspendisse condimentum pellentesque
+            varius. Nullam molestie dictum pellentesque. Nunc felis sem,
+            elementum a sapien a, consectetur ullamcorper tellus. Nullam porta
+            tempus nisl, in vehicula quam congue eget.
+          </p>
+        ),
+      },
+    ],
+  },
+} as ComponentMeta<typeof Tabs>;
+
+const Template: ComponentStory<typeof Tabs> = (args) => <Tabs {...args} />;
+
+export const Example = Template.bind({});
+Example.args = {};
+Example.parameters = {
+  docs: {
+    description: {
+      story: 'This is how the component might look like.',
+    },
+  },
+};

--- a/src/components/Tabs/Tabs.test.tsx
+++ b/src/components/Tabs/Tabs.test.tsx
@@ -1,0 +1,250 @@
+import assert from 'assert';
+
+import React from 'react';
+import { act, screen, render as renderRtl } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { lastItem } from '@/utils/arrayUtils';
+
+import type { TabItem, TabsProps } from './Tabs';
+import { Tabs } from './Tabs';
+
+const user = userEvent.setup();
+
+// Test data:
+const itemInfo = [
+  {
+    name: 'Item 1',
+    textContent: 'Lorem ipsum dolor sit amet.',
+  },
+  {
+    name: 'Item 2',
+    textContent: 'Etiam ac magna pretium, laoreet.',
+  },
+  {
+    name: 'Item 3',
+    textContent: 'Phasellus convallis porta commodo. Vivamus.',
+  },
+];
+const items: TabItem[] = itemInfo.map((item) => ({
+  name: item.name,
+  content: <p>{item.textContent}</p>,
+}));
+const defaultProps: TabsProps = {
+  items,
+};
+
+describe('Tabs', () => {
+  it('Renders expected elements', () => {
+    render();
+    expect(getTablist()).toBeInTheDocument();
+    expect(getTabs()).toHaveLength(items.length);
+    expect(getTabpanel()).toBeInTheDocument();
+  });
+
+  it('Selects first tab by default', () => {
+    render();
+    expectSelected(getTab(0));
+    expectNotSelected(getTab(1));
+    expectNotSelected(getTab(2));
+    expect(getTabpanel()).toHaveTextContent(itemInfo[0].textContent);
+  });
+
+  it('Initially selects tab given in the activeTab property', () => {
+    render({ activeTab: items[1].name });
+    expectSelected(getTab(1));
+    expectNotSelected(getTab(0));
+    expectNotSelected(getTab(2));
+    expect(getTabpanel()).toHaveTextContent(itemInfo[1].textContent);
+  });
+
+  it('Sets given tab id on tab', () => {
+    const tabId = 'some-unique-tab-id';
+    render({ items: [...items, { tabId, name: 'Item 4', content: <span /> }] });
+    expect(getLastTab()).toHaveAttribute('id', tabId);
+  });
+
+  it('Sets given panel id on tab panel', () => {
+    const panelId = 'some-unique-panel-id';
+    const textContent = 'In dignissim risus enim, sed.';
+    const content = <p>{textContent}</p>;
+    const tabs = [...items, { panelId, name: 'Item 4', content }];
+    render({ items: tabs });
+    expect(document.getElementById(panelId)).toHaveTextContent(textContent);
+  });
+
+  it('Links corresponding tabs and panels to each other with accessibility attributes', () => {
+    render();
+    items.forEach((item, i) => {
+      const panelId = getTab(i).getAttribute('aria-controls');
+      const panel = screen.getByLabelText(items[i].name);
+      expect(panel).toHaveAttribute('id', panelId);
+    });
+  });
+
+  it('Selects and focuses on tab when user clicks on it', async () => {
+    render();
+    for (let i = 0; i < items.length; i++) {
+      await act(() => user.click(getTab(i)));
+      expectSelectedIndex(i);
+      expect(getTab(i)).toHaveFocus();
+    }
+  });
+
+  it('Does not focus on any tab by default', () => {
+    render();
+    getTabs().forEach((tab) => expect(tab).not.toHaveFocus());
+  });
+
+  it('Focuses on the first tab when user presses the tab key', async () => {
+    const { container } = render();
+    await act(() => user.click(container));
+    await act(() => user.tab());
+    expect(getTab(0)).toHaveFocus();
+  });
+
+  it('Moves focus out when one tab has focus and user presses the tab key', async () => {
+    render();
+    await act(() => user.click(getTab(1)));
+    expect(getTab(1)).toHaveFocus();
+    await act(() => user.tab());
+    getTabs().forEach((tab) => expect(tab).not.toHaveFocus());
+  });
+
+  it('Moves focus to the right when user presses the right arrow key', async () => {
+    render();
+    await act(() => user.click(getTab(0)));
+    expect(getTab(0)).toHaveFocus();
+    await act(() => user.keyboard('{ArrowRight}'));
+    expect(getTab(1)).toHaveFocus();
+    await act(() => user.keyboard('{ArrowRight}'));
+    expect(getTab(2)).toHaveFocus();
+  });
+
+  it('Moves focus to the left when user presses the left arrow key', async () => {
+    render();
+    await act(() => user.click(getTab(2)));
+    expect(getTab(2)).toHaveFocus();
+    await act(() => user.keyboard('{ArrowLeft}'));
+    expect(getTab(1)).toHaveFocus();
+    await act(() => user.keyboard('{ArrowLeft}'));
+    expect(getTab(0)).toHaveFocus();
+  });
+
+  it('Moves focus to the first tab when the last tab is focused and user presses the right arrow key', async () => {
+    render();
+    await act(() => user.click(getLastTab()));
+    expect(getLastTab()).toHaveFocus();
+    await act(() => user.keyboard('{ArrowRight}'));
+    expect(getTab(0)).toHaveFocus();
+  });
+
+  it('Moves focus to the last tab when the first tab is focused and user presses the left arrow key', async () => {
+    render();
+    await act(() => user.click(getTab(0)));
+    expect(getTab(0)).toHaveFocus();
+    await act(() => user.keyboard('{ArrowLeft}'));
+    expect(getLastTab()).toHaveFocus();
+  });
+
+  it('Selects tab when user navigates with arrow keys and presses the enter key', async () => {
+    render();
+    await act(() => user.click(getTab(0)));
+    await act(() => user.keyboard('{ArrowRight}'));
+    await act(() => user.keyboard('{Enter}'));
+    expectSelected(getTab(1));
+  });
+
+  it('Selects tab when user navigates with arrow keys and presses the space key', async () => {
+    render();
+    await act(() => user.click(getTab(0)));
+    await act(() => user.keyboard('{ArrowRight}'));
+    await act(() => user.keyboard('{Space}'));
+    expectSelected(getTab(1));
+  });
+
+  it('Throws error if item names are not unique', () => {
+    const renderFn = () => {
+      render({ items: [...items, { name: items[0].name, content: <p /> }] });
+    };
+    jest.spyOn(console, 'error').mockImplementation(jest.fn()); // Keeps the console output clean
+    expect(renderFn).toThrow('Each tab name must be unique.');
+  });
+
+  it('Throws error if the name given in activeTab is not present in the item list', () => {
+    const renderFn = () => {
+      render({ activeTab: 'Some name that is not in the list' });
+    };
+    jest.spyOn(console, 'error').mockImplementation(jest.fn()); // Keeps the console output clean
+    const error = 'The given active tab name must exist in the list of items.';
+    expect(renderFn).toThrow(error);
+  });
+
+  it('Switches selected tab when rerendered with a new value in the activeTab property', () => {
+    const { rerender } = render();
+    rerender(
+      <Tabs
+        {...defaultProps}
+        activeTab={items[1].name}
+      />,
+    );
+    expectSelected(getTab(1));
+  });
+
+  it("Calls the onChange function with the selected tab's name as a parameter when user selects a tab using the mouse", async () => {
+    const onChange = jest.fn();
+    render({ onChange });
+    await act(() => user.click(getTab(1)));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(items[1].name);
+  });
+
+  it("Calls the onChange function with the selected tab's name as a parameter when user selects a tab using the enter key", async () => {
+    const onChange = jest.fn();
+    render({ onChange });
+    await act(() => user.click(getTab(0)));
+    await act(() => user.keyboard('{ArrowRight}'));
+    await act(() => user.keyboard('{Enter}'));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(items[1].name);
+  });
+
+  it("Calls the onChange function with the selected tab's name as a parameter when user selects a tab using the space key", async () => {
+    const onChange = jest.fn();
+    render({ onChange });
+    await act(() => user.click(getTab(0)));
+    await act(() => user.keyboard('{ArrowRight}'));
+    await act(() => user.keyboard('{Space}'));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(items[1].name);
+  });
+});
+
+const render = (props?: Partial<TabsProps>) => {
+  return renderRtl(
+    <Tabs
+      {...defaultProps}
+      {...props}
+    />,
+  );
+};
+
+const getTablist = () => screen.getByRole('tablist');
+const getTabs = () => screen.getAllByRole('tab');
+const getTab = (index: number) => getTabs()[index];
+const getLastTab = () => {
+  const last = lastItem(getTabs());
+  assert(last !== undefined);
+  return last;
+};
+const getTabpanel = () => screen.getByRole('tabpanel');
+
+const expectSelected = (tab: HTMLElement) =>
+  expect(tab).toHaveAttribute('aria-selected', 'true');
+const expectNotSelected = (tab: HTMLElement) =>
+  expect(tab).toHaveAttribute('aria-selected', 'false');
+const expectSelectedIndex = (index: number) =>
+  getTabs().forEach((tab, i) => {
+    if (index === i) expectSelected(tab);
+    else expectNotSelected(tab);
+  });

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,0 +1,144 @@
+import type { KeyboardEventHandler } from 'react';
+import React, { useEffect, useId, useRef, useState } from 'react';
+import cn from 'classnames';
+
+import { areItemsUnique } from '@/utils/arrayUtils';
+import { useUpdate } from '@/hooks';
+
+import classes from './Tabs.module.css';
+
+export interface TabItem {
+  name: string;
+  content: React.ReactNode;
+  tabId?: string;
+  panelId?: string;
+}
+
+export interface TabsProps {
+  activeTab?: string;
+  items: TabItem[];
+  onChange?: (name: string) => void;
+}
+
+interface Ids {
+  panelId: string;
+  tabId: string;
+}
+
+export const Tabs = ({ activeTab, items, onChange }: TabsProps) => {
+  if (!areItemsUnique(items.map(({ name }) => name))) {
+    throw Error('Each tab name must be unique.');
+  }
+  if (
+    activeTab !== undefined &&
+    !items.some(({ name }) => name === activeTab)
+  ) {
+    throw Error('The given active tab name must exist in the list of items.');
+  }
+
+  const findTabIndexByName = (name: string) =>
+    items.findIndex((item) => item.name === name);
+  const initialTab = activeTab ?? items[0].name;
+  const [visiblePanel, setVisiblePanel] = useState<string>(initialTab);
+  const [focusIndex, setFocusIndex] = useState<number>(
+    findTabIndexByName(initialTab),
+  );
+  useEffect(() => setVisiblePanel(initialTab), [initialTab]);
+  const tablistRef = useRef<HTMLDivElement>(null);
+  const idBase = useId();
+  const lastIndex = items.length - 1;
+
+  useUpdate(() => {
+    tablistRef.current
+      ?.querySelectorAll<HTMLButtonElement>('[role="tab"]')
+      [focusIndex].focus();
+  }, [focusIndex]);
+
+  const selectTab = (name: string) => {
+    visiblePanel !== name && onChange && onChange(name);
+    setVisiblePanel(name);
+    setFocusIndex(findTabIndexByName(name));
+  };
+
+  const moveFocusRight = () =>
+    focusIndex !== undefined &&
+    setFocusIndex(focusIndex === lastIndex ? 0 : focusIndex + 1);
+  const moveFocusLeft = () =>
+    focusIndex !== undefined &&
+    setFocusIndex(focusIndex === 0 ? lastIndex : focusIndex - 1);
+
+  const onKeyDown =
+    (name: string) => (event: Parameters<KeyboardEventHandler>[0]) => {
+      switch (event.key) {
+        case 'ArrowRight':
+          moveFocusRight();
+          break;
+        case 'ArrowLeft':
+          moveFocusLeft();
+          break;
+        case 'Space':
+          selectTab(name);
+      }
+    };
+
+  const idFromName = (name: string) => name.replace(/\s/, '_');
+  const idMap = new Map<string, Ids>(
+    items.map((item) => [
+      item.name,
+      {
+        panelId: item.panelId ?? `${idBase}-panel-${idFromName(item.name)}`,
+        tabId: item.tabId ?? `${idBase}-tab-${idFromName(item.name)}`,
+      },
+    ]),
+  );
+
+  return (
+    <div className={classes.tabs}>
+      <div
+        className={classes['tabs__tablist']}
+        ref={tablistRef}
+        role='tablist'
+      >
+        {items.map((item, i) => {
+          const isSelected = item.name === visiblePanel;
+          const ids = idMap.get(item.name);
+          const className = cn(
+            classes['tabs__tablist__tab'],
+            isSelected && classes['tabs__tablist__tab--selected'],
+          );
+          return (
+            <button
+              aria-controls={ids?.panelId}
+              aria-selected={isSelected}
+              className={className}
+              id={ids?.tabId}
+              key={item.name}
+              onClick={() => selectTab(item.name)}
+              onKeyDown={onKeyDown(item.name)}
+              role='tab'
+              tabIndex={focusIndex === i ? 0 : -1}
+            >
+              {item.name}
+            </button>
+          );
+        })}
+      </div>
+      <hr className={classes['tabs__divider']} />
+      {items.map((item) => {
+        const ids = idMap.get(item.name);
+        return (
+          <div
+            className={classes['tabs__tabpanel']}
+            aria-labelledby={ids?.tabId}
+            hidden={item.name !== visiblePanel}
+            id={ids?.panelId}
+            key={ids?.panelId}
+            role='tabpanel'
+          >
+            {item.content}
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/Tabs/index.ts
+++ b/src/components/Tabs/index.ts
@@ -1,0 +1,1 @@
+export { Tabs } from './Tabs';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -34,3 +34,4 @@ export { CheckboxGroup, CheckboxGroupVariant } from './CheckboxGroup';
 export { FieldSet, FieldSetSize } from './FieldSet';
 export { Pagination } from './Pagination';
 export { Select } from './Select';
+export { Tabs } from './Tabs';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,3 @@
+export { useEventListener } from './useEventListener';
+export { useKeyboardEventListener } from './useKeyboardEventListener';
+export { useUpdate } from './useUpdate';

--- a/src/hooks/useUpdate.test.ts
+++ b/src/hooks/useUpdate.test.ts
@@ -18,7 +18,7 @@ describe('useUpdate', () => {
     expect(effect).toHaveBeenCalledTimes(1);
   });
 
-  it('Does not call effect on secend render if there is no dependency change', () => {
+  it('Does not call effect on second render if there is no dependency change', () => {
     const effect = jest.fn();
     renderHook(() => useUpdate(effect, [])).rerender();
     expect(effect).not.toHaveBeenCalled();

--- a/src/hooks/useUpdate.test.ts
+++ b/src/hooks/useUpdate.test.ts
@@ -1,0 +1,26 @@
+import { renderHook } from '@testing-library/react';
+
+import { useUpdate } from '@/hooks';
+
+describe('useUpdate', () => {
+  it('Does not call effect on first render', () => {
+    const effect = jest.fn();
+    renderHook(() => useUpdate(effect, []));
+    expect(effect).not.toHaveBeenCalled();
+  });
+
+  it('Calls effect on second render if a dependency changes', () => {
+    const effect = jest.fn();
+    let dependency = 'Something';
+    const { rerender } = renderHook(() => useUpdate(effect, [dependency]));
+    dependency = 'Something else';
+    rerender();
+    expect(effect).toHaveBeenCalledTimes(1);
+  });
+
+  it('Does not call effect on secend render if there is no dependency change', () => {
+    const effect = jest.fn();
+    renderHook(() => useUpdate(effect, [])).rerender();
+    expect(effect).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useUpdate.ts
+++ b/src/hooks/useUpdate.ts
@@ -1,0 +1,14 @@
+import { useEffect, useRef } from 'react';
+
+// This hook corresponds to the componentDidUpdate function in class components.
+// It is similar to useEffect, but does not run on the first render.
+export const useUpdate: typeof useEffect = (effect, deps) => {
+  const isFirst = useRef(true);
+  useEffect(() => {
+    if (isFirst.current) {
+      isFirst.current = false;
+    } else {
+      return effect();
+    }
+  }, deps); // eslint-disable-line react-hooks/exhaustive-deps
+};

--- a/src/utils/arrayUtils.test.ts
+++ b/src/utils/arrayUtils.test.ts
@@ -1,4 +1,4 @@
-import { arraysEqual } from '@/utils/arrayUtils';
+import { areItemsUnique, arraysEqual, lastItem } from '@/utils/arrayUtils';
 
 describe('arrayUtils', () => {
   describe('arraysEqual', () => {
@@ -46,6 +46,43 @@ describe('arrayUtils', () => {
       expect(arraysEqual(['a', 'b', 'c'], ['å', 'b', 'c'])).toBe(false);
       expect(arraysEqual([true, false], [true, true])).toBe(false);
       expect(arraysEqual([1, 'b', true], [0, 'b', true])).toBe(false);
+    });
+  });
+
+  describe('lastItem', () => {
+    it('Returns last element of given array', () => {
+      expect(lastItem([1, 2, 3])).toBe(3);
+      expect(lastItem([true, false])).toBe(false);
+      expect(lastItem(['test'])).toBe('test');
+    });
+
+    it('Returns undefined if given array is empty', () => {
+      expect(lastItem([])).toBeUndefined();
+    });
+  });
+
+  describe('areItemsUnique', () => {
+    it('Returns true if all items are unique', () => {
+      expect(areItemsUnique([1, 2, 3])).toBe(true);
+      expect(areItemsUnique(['a', 'b', 'c'])).toBe(true);
+      expect(areItemsUnique(['abc', 'bcd', 'cde'])).toBe(true);
+      expect(areItemsUnique([true, false])).toBe(true);
+      expect(areItemsUnique([1, 'b', true])).toBe(true);
+      expect(areItemsUnique([0, '', false, null, undefined])).toBe(true);
+    });
+
+    it('Returns true if array is empty', () => {
+      expect(areItemsUnique([])).toBe(true);
+    });
+
+    it('Returns false if there is at least one duplicated item', () => {
+      expect(areItemsUnique([1, 2, 1])).toBe(false);
+      expect(areItemsUnique(['a', 'a', 'c'])).toBe(false);
+      expect(areItemsUnique(['abc', 'bcd', 'bcd'])).toBe(false);
+      expect(areItemsUnique([true, false, true])).toBe(false);
+      expect(areItemsUnique([1, 'b', false, 1])).toBe(false);
+      expect(areItemsUnique([null, null])).toBe(false);
+      expect(areItemsUnique([undefined, undefined])).toBe(false);
     });
   });
 });

--- a/src/utils/arrayUtils.ts
+++ b/src/utils/arrayUtils.ts
@@ -8,3 +8,13 @@ export function arraysEqual<T>(array1?: T[], array2?: T[]): boolean {
   }
   return true;
 }
+
+// Returns the last item of the array or undefined if the array is empty
+export function lastItem<T>(array: T[]): T | undefined {
+  return array[array.length - 1];
+}
+
+// Returns true if all items in the array are unique and false otherwise
+export function areItemsUnique<T>(array: T[]): boolean {
+  return array.length === new Set(array).size;
+}


### PR DESCRIPTION
## Description
This pull request adds a tab navigation component similar to the one used in Altinn Studio. It also adds a `useUpdate` hook and a couple of array handling utils. At the moment, there are no Figma tokens related to this component.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
