### PR TITLE
Remove PNG imports

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -88,11 +88,6 @@ module.exports = {
       ],
     });
 
-    config.module.rules.push({
-      test: /\.png$/i,
-      type: 'asset/resource'
-    });
-
     config.resolve.alias = {
       ...config.resolve.alias,
       '@': AppSourceDir,

--- a/__mocks__/png.ts
+++ b/__mocks__/png.ts
@@ -1,2 +1,0 @@
-export default 'PngURL';
-export const ReactComponent = 'div';

--- a/custom.d.ts
+++ b/custom.d.ts
@@ -11,8 +11,3 @@ declare module '*.css' {
   const styles: { [className: string]: string };
   export default styles;
 }
-
-declare module '*.png' {
-  const value: any;
-  export = value;
-}

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,6 @@ module.exports = {
   moduleNameMapper: {
     '.(css|less|scss)$': 'identity-obj-proxy',
     '\\.svg$': '<rootDir>/__mocks__/svg.ts',
-    '\\.png$': '<rootDir>/__mocks__/png.ts',
     '^@/(.*)$': '<rootDir>/src/$1',
     '^@test/(.*)$': '<rootDir>/test/$1',
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@babel/core": "7.20.2",
     "@mdx-js/react": "2.1.5",
     "@rollup/plugin-commonjs": "23.0.2",
-    "@rollup/plugin-image": "3.0.1",
     "@rollup/plugin-json": "5.0.1",
     "@rollup/plugin-node-resolve": "15.0.1",
     "@rollup/plugin-typescript": "9.0.2",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -2,7 +2,6 @@ import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import typescript from '@rollup/plugin-typescript';
 import json from '@rollup/plugin-json';
-import image from '@rollup/plugin-image';
 import dts from 'rollup-plugin-dts';
 import postcss from 'rollup-plugin-postcss';
 import peerDepsExternal from 'rollup-plugin-peer-deps-external';
@@ -45,7 +44,6 @@ export default [
       svgr({ exportType: 'named' }),
       postcss(),
       terser(),
-      image(),
     ],
   },
   {

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -1,7 +1,3 @@
-import UrlIcon from 'leaflet/dist/images/marker-icon.png';
-import RetinaUrlIcon from 'leaflet/dist/images/marker-icon-2x.png';
-import ShadowUrlIcon from 'leaflet/dist/images/marker-shadow.png';
-import { icon } from 'leaflet';
 import {
   AttributionControl,
   MapContainer,
@@ -94,19 +90,8 @@ export const Map = ({
 
 type LocationMarkerProps = Pick<MapProps, 'markerLocation'>;
 function LocationMarker({ markerLocation }: LocationMarkerProps) {
-  const markerIcon = icon({
-    iconUrl: UrlIcon,
-    iconRetinaUrl: RetinaUrlIcon,
-    shadowUrl: ShadowUrlIcon,
-    iconSize: [25, 41],
-    iconAnchor: [12, 41],
-  });
-
   return markerLocation ? (
-    <Marker
-      position={locationToTuple(markerLocation)}
-      icon={markerIcon}
-    />
+    <Marker position={locationToTuple(markerLocation)} />
   ) : null;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,7 +23,6 @@ __metadata:
     "@radix-ui/react-popover": ^1.0.0
     "@react-hookz/web": ^19.0.0
     "@rollup/plugin-commonjs": 23.0.2
-    "@rollup/plugin-image": 3.0.1
     "@rollup/plugin-json": 5.0.1
     "@rollup/plugin-node-resolve": 15.0.1
     "@rollup/plugin-typescript": 9.0.2
@@ -3357,21 +3356,6 @@ __metadata:
     rollup:
       optional: true
   checksum: bd203a6e6fbcdc523f5d47a8a9e6b719f853270fbfa608c636124c213ec4b2a15026121e1e4faa820f52546425050f4c833bbf6bc58959909025cbc99c6d5df3
-  languageName: node
-  linkType: hard
-
-"@rollup/plugin-image@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@rollup/plugin-image@npm:3.0.1"
-  dependencies:
-    "@rollup/pluginutils": ^5.0.1
-    mini-svg-data-uri: ^1.4.4
-  peerDependencies:
-    rollup: ^1.20.0||^2.0.0||^3.0.0
-  peerDependenciesMeta:
-    rollup:
-      optional: true
-  checksum: a48e35f482189d27c608fb9ccc69128a70210cd3fa3ddcfa249fd99a337c9518bfd8bfce9da97cf4ee8c37833bdbfde76806603628036af79e4ea1d60c2e49f4
   languageName: node
   linkType: hard
 
@@ -14810,15 +14794,6 @@ __metadata:
   version: 1.0.1
   resolution: "min-indent@npm:1.0.1"
   checksum: bfc6dd03c5eaf623a4963ebd94d087f6f4bbbfd8c41329a7f09706b0cb66969c4ddd336abeb587bc44bc6f08e13bf90f0b374f9d71f9f01e04adc2cd6f083ef1
-  languageName: node
-  linkType: hard
-
-"mini-svg-data-uri@npm:^1.4.4":
-  version: 1.4.4
-  resolution: "mini-svg-data-uri@npm:1.4.4"
-  bin:
-    mini-svg-data-uri: cli.js
-  checksum: 997f1fbd8d59a70f03761e18626d335197a3479cb9d1ff75678e4b64b864d32a0b8fc18115eabde035e5299b8b4a354a78e57dd6ac10f9d604162a6170898d09
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
The PNG imports in the `Map` component do not seem to be necessary, as they are the same as the ones in the default settings of of the `Marker` component. Removing them will simplify installation of the design system for Webpack users, as they won't have to adjust their configuration.

## Related Issue(s)
- #214 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
