### PR TITLE
Fixes in tabs component

### DIFF
--- a/src/components/Tabs/Tabs.module.css
+++ b/src/components/Tabs/Tabs.module.css
@@ -22,6 +22,8 @@
   display: flex;
   gap: var(--tablist-gap);
   margin: 0 var(--tablist-margin_horizontal);
+  position: relative;
+  z-index: 1;
 }
 
 .tabs__tablist__tab {
@@ -65,7 +67,6 @@
   position: absolute;
   top: var(--tab-height);
   width: 100%;
-  z-index: -1;
 }
 
 .tabs__tabpanel {

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -30,9 +30,11 @@ export default {
                         It is useful to give a structured view of elements that do not have to be visible all at the same time.
                         Tabs are selected using the mouse or by keyboard navigation. On the keyboard, left and right arrow keys are used to switch focus and the enter or space keys are used to open the focused tab.
                         The component accepts a list of \`TabItem\`s (\`item\` property) consisting of a tab name and some tab panel content.
+                        There is also an optional \`value\` property that defaults to the value given in the \`name\` property.
+                        This may be useful together with the \`activeTab\` and \`onChange\` properties to identify tabs without relying on their name, which may be a dynamic value.
                         It is also possible to specify IDs for the tab and the panel components (they will be generated if not given).
                         The \`activeTab\` property can be used to define which tab should be selected by default. It defaults to the first tab.
-                        The \`onChange\` property optional and can be used to trigger some function the user switches to another tab. It is called with the tab name as a parameter.`}
+                        The \`onChange\` property is optional and can be used to trigger some function when the user switches to another tab. It is called with the tab value as a parameter.`}
         />
       ),
     },

--- a/src/components/Tabs/index.ts
+++ b/src/components/Tabs/index.ts
@@ -1,1 +1,2 @@
 export { Tabs } from './Tabs';
+export type { TabsProps, TabItem } from './Tabs';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -42,6 +42,7 @@ export type {
   MultipleOnChangeEvent,
 } from './Select';
 export { Tabs } from './Tabs';
+export type { TabsProps, TabItem } from './Tabs';
 export { RadioGroup } from './RadioGroup';
 export type { RadioGroupSize, RadioGroupVariant } from './RadioGroup';
 export { RadioButton } from './RadioButton';


### PR DESCRIPTION
## Description
- Added an optional `value` property to `TabItem`. It's not ideal to use the displayed name to identify tabs in cases where this is a dynamic value.
- Increased the `z-index` values on the tablist and the divider, as the current value (-1) makes the divider hide between background components.
- Removed the `idMap` and put all handling of undefined values in one place. It's a bit cleaner like this.

## Related Issue(s)
- #208 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
