### PR TITLE
Table row selection bug

### DIFF
--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -44,7 +44,9 @@ export const TableRow = ({
     }
   };
   const isSelected =
-    JSON.stringify(rowData) === JSON.stringify(selectedValue) ? true : false;
+    selectRows &&
+    typeof rowData !== 'undefined' &&
+    JSON.stringify(rowData) === JSON.stringify(selectedValue);
 
   return (
     <SortContext.Provider value={{ selectSort }}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previously, if `selectRows` is false, and no `rowData` was provided, every row would appear to be selected because `"undefined" === "undefined"` evaluates to true for every row. Additionally, `isSelected` did not require `selectRows` to be `true` in the `TableContext`.

## Related Issue(s)
- ~~#{issue number}~~

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- ~~[ ] Relevant automated test added (if you find this hard, leave it and we'll help out)~~
- [ ] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
