### PR TITLE
Wrap map component coordinates (#243)

### DIFF
--- a/src/components/Map/Map.test.tsx
+++ b/src/components/Map/Map.test.tsx
@@ -35,7 +35,22 @@ describe('Map', () => {
 
       expect(handleMapClicked).toHaveBeenCalledWith({
         latitude: 59.265880628258095,
-        longitude: 10.371093750000002,
+        longitude: 10.37109375,
+      } as Location);
+    });
+
+    it('should call onClick with longitude between 180 and -180 even when map is wrapped', async () => {
+      const handleMapClicked = jest.fn();
+      render({
+        onClick: handleMapClicked,
+      });
+
+      // Click so that the world is wrapped
+      await clickMap(2500, 0);
+
+      expect(handleMapClicked).toHaveBeenCalledWith({
+        latitude: 59.265880628258095,
+        longitude: -129.90234375,
       } as Location);
     });
 

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -119,9 +119,10 @@ const MapClickHandler = ({ onClick, readOnly }: MapClickHandlerProps) => {
   useMapEvents({
     click: (map) => {
       if (onClick && !readOnly) {
+        const wrappedLatLng = map.latlng.wrap();
         onClick({
-          latitude: map.latlng.lat,
-          longitude: map.latlng.lng,
+          latitude: wrappedLatLng.lat,
+          longitude: wrappedLatLng.lng,
         });
       }
     },


### PR DESCRIPTION
## Description

Wrap map component coordinates so only valid coordinates between -90 to 90 for latitude and -180 to 180 for longitude is returned.

## Related Issue(s)
- #243

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
