### PR TITLE
Add print style for panel

### DIFF
--- a/src/components/Panel/Panel.module.css
+++ b/src/components/Panel/Panel.module.css
@@ -58,6 +58,21 @@
   }
 }
 
+/* print style */
+@media print {
+  .panel {
+    --panel-y-padding: var(--component-panel-space-padding-y-xs);
+    --panel-x-padding: var(--component-panel-space-padding-x-xs);
+    --panel-content-gap: var(--component-panel-space-gap-xs);
+    --panel-pointer-width: calc(var(--component-panel-size-icon-xs) / 2);
+    --panel-pointer-height: calc(var(--panel-pointer-width) / 2);
+    --panel-body-font_size: var(--component-panel-font_size-body-breakpoint_sm);
+    --panel-header-font_size: var(
+      --component-panel-font_size-header-breakpoint_sm
+    );
+  }
+}
+
 .panel {
   width: 100%;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Padding and fontsize for panel is currently only defined for `@media only screen`, so I added a separate styling for `@media print`. 

Panel currently looks like this when printing:
![image](https://user-images.githubusercontent.com/47412359/210214423-14ba43d6-45bf-448c-8c55-ad6e398c91f4.png)


## Related Issue(s)
- https://github.com/Altinn/app-frontend-react/issues/710
- https://github.com/Altinn/app-frontend-react/pull/736

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
-  ~~Relevant automated test added (if you find this hard, leave it and we'll help out)~~
- [x] All tests run green

## Documentation
- ~~User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
