### PR TITLE
Re-doing "Remove PNG imports"

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -88,11 +88,6 @@ module.exports = {
       ],
     });
 
-    config.module.rules.push({
-      test: /\.png$/i,
-      type: 'asset/resource'
-    });
-
     config.resolve.alias = {
       ...config.resolve.alias,
       '@': AppSourceDir,

--- a/__mocks__/png.ts
+++ b/__mocks__/png.ts
@@ -1,2 +1,0 @@
-export default 'PngURL';
-export const ReactComponent = 'div';

--- a/custom.d.ts
+++ b/custom.d.ts
@@ -11,8 +11,3 @@ declare module '*.css' {
   const styles: { [className: string]: string };
   export default styles;
 }
-
-declare module '*.png' {
-  const value: any;
-  export = value;
-}

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,6 @@ module.exports = {
   moduleNameMapper: {
     '.(css|less|scss)$': 'identity-obj-proxy',
     '\\.svg$': '<rootDir>/__mocks__/svg.ts',
-    '\\.png$': '<rootDir>/__mocks__/png.ts',
     '^@/(.*)$': '<rootDir>/src/$1',
     '^@test/(.*)$': '<rootDir>/test/$1',
   },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@babel/core": "7.20.7",
     "@mdx-js/react": "2.2.1",
     "@rollup/plugin-commonjs": "24.0.0",
-    "@rollup/plugin-image": "3.0.1",
     "@rollup/plugin-json": "6.0.0",
     "@rollup/plugin-node-resolve": "15.0.1",
     "@rollup/plugin-typescript": "10.0.1",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -2,7 +2,6 @@ import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import typescript from '@rollup/plugin-typescript';
 import json from '@rollup/plugin-json';
-import image from '@rollup/plugin-image';
 import dts from 'rollup-plugin-dts';
 import postcss from 'rollup-plugin-postcss';
 import peerDepsExternal from 'rollup-plugin-peer-deps-external';
@@ -45,7 +44,6 @@ export default [
       svgr({ exportType: 'named' }),
       postcss(),
       terser(),
-      image(),
     ],
   },
   {

--- a/src/components/Map/Map.test.tsx
+++ b/src/components/Map/Map.test.tsx
@@ -147,7 +147,7 @@ async function clickMap(clientX = 0, clientY = 0) {
 }
 
 const render = (props: Partial<MapProps> = {}) => {
-  const allProps = {
+  const allProps: MapProps = {
     readOnly: false,
     layers: undefined,
     centerLocation: {
@@ -159,6 +159,9 @@ const render = (props: Partial<MapProps> = {}) => {
       latitude: 59.2641592,
       longitude: 10.4036248,
     } as Location,
+    markerIcon: {
+      iconUrl: 'marker.png',
+    },
     onClick: jest.fn(),
     ...props,
   };

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -6,8 +6,10 @@ import {
   useMapEvents,
 } from 'react-leaflet';
 import React from 'react';
+import { icon } from 'leaflet';
 
 import classes from './Map.module.css';
+
 import 'leaflet/dist/leaflet.css';
 
 // Default is center of Norway
@@ -40,6 +42,36 @@ export interface MapLayer {
   subdomains?: string[];
 }
 
+/**
+ * It is expected you pass in the default icons when using the Map component, unless you want to provide your own icon.
+ *
+ * Example:
+ *   import Marker from 'leaflet/dist/images/marker-icon.png';
+ *   import RetinaMarker from 'leaflet/dist/images/marker-icon-2x.png';
+ *   import MarkerShadow from 'leaflet/dist/images/marker-shadow.png';
+ *
+ *   <Map ... markerIcon={{
+ *     iconUrl: Marker,
+ *     iconRetinaUrl: RetinaMarker,
+ *     shadowUrl: MarkerShadow,
+ *     iconSize: [25, 41],
+ *     iconAnchor: [12, 41],
+ *   }} />
+ *
+ * This example requires your build system to support image loading (but you can provide the URLs for static icon files
+ * if your build system doesn't support image loading).
+ */
+export interface MapIconOptions {
+  iconUrl: string;
+  iconRetinaUrl?: string | undefined;
+  iconSize?: [number, number] | undefined;
+  iconAnchor?: [number, number] | undefined;
+  shadowUrl?: string | undefined;
+  shadowRetinaUrl?: string | undefined;
+  shadowSize?: [number, number] | undefined;
+  shadowAnchor?: [number, number] | undefined;
+}
+
 export interface MapProps {
   readOnly?: boolean;
   layers?: MapLayer[];
@@ -47,6 +79,7 @@ export interface MapProps {
   zoom?: number;
   markerLocation?: Location;
   onClick?: (location: Location) => void;
+  markerIcon: MapIconOptions;
 }
 
 export const Map = ({
@@ -55,6 +88,7 @@ export const Map = ({
   centerLocation = DefaultCenterLocation,
   zoom = DefaultZoom,
   markerLocation,
+  markerIcon,
   onClick,
 }: MapProps) => {
   return (
@@ -79,7 +113,12 @@ export const Map = ({
         />
       ))}
       <AttributionControl prefix={false} />
-      <LocationMarker markerLocation={markerLocation} />
+      {markerLocation ? (
+        <Marker
+          position={locationToTuple(markerLocation)}
+          icon={icon(markerIcon)}
+        />
+      ) : null}
       <MapClickHandler
         readOnly={readOnly}
         onClick={onClick}
@@ -87,13 +126,6 @@ export const Map = ({
     </MapContainer>
   );
 };
-
-type LocationMarkerProps = Pick<MapProps, 'markerLocation'>;
-function LocationMarker({ markerLocation }: LocationMarkerProps) {
-  return markerLocation ? (
-    <Marker position={locationToTuple(markerLocation)} />
-  ) : null;
-}
 
 function locationToTuple(location: Location): [number, number] {
   return [location.latitude, location.longitude];

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -1,7 +1,3 @@
-import UrlIcon from 'leaflet/dist/images/marker-icon.png';
-import RetinaUrlIcon from 'leaflet/dist/images/marker-icon-2x.png';
-import ShadowUrlIcon from 'leaflet/dist/images/marker-shadow.png';
-import { icon } from 'leaflet';
 import {
   AttributionControl,
   MapContainer,
@@ -94,19 +90,8 @@ export const Map = ({
 
 type LocationMarkerProps = Pick<MapProps, 'markerLocation'>;
 function LocationMarker({ markerLocation }: LocationMarkerProps) {
-  const markerIcon = icon({
-    iconUrl: UrlIcon,
-    iconRetinaUrl: RetinaUrlIcon,
-    shadowUrl: ShadowUrlIcon,
-    iconSize: [25, 41],
-    iconAnchor: [12, 41],
-  });
-
   return markerLocation ? (
-    <Marker
-      position={locationToTuple(markerLocation)}
-      icon={markerIcon}
-    />
+    <Marker position={locationToTuple(markerLocation)} />
   ) : null;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,7 +22,6 @@ __metadata:
     "@navikt/ds-icons": ^2.0.0
     "@radix-ui/react-popover": ^1.0.0
     "@rollup/plugin-commonjs": 24.0.0
-    "@rollup/plugin-image": 3.0.1
     "@rollup/plugin-json": 6.0.0
     "@rollup/plugin-node-resolve": 15.0.1
     "@rollup/plugin-typescript": 10.0.1
@@ -3465,21 +3464,6 @@ __metadata:
     rollup:
       optional: true
   checksum: e2a1bf295bbb45ab56747f7ce636d4b94046bfecc758a64c7276823b80271e0ba1196642c232aa61d1b1a98abeaddad45486c7227ec19a97d19d16f7661d49a6
-  languageName: node
-  linkType: hard
-
-"@rollup/plugin-image@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@rollup/plugin-image@npm:3.0.1"
-  dependencies:
-    "@rollup/pluginutils": ^5.0.1
-    mini-svg-data-uri: ^1.4.4
-  peerDependencies:
-    rollup: ^1.20.0||^2.0.0||^3.0.0
-  peerDependenciesMeta:
-    rollup:
-      optional: true
-  checksum: a48e35f482189d27c608fb9ccc69128a70210cd3fa3ddcfa249fd99a337c9518bfd8bfce9da97cf4ee8c37833bdbfde76806603628036af79e4ea1d60c2e49f4
   languageName: node
   linkType: hard
 
@@ -14929,15 +14913,6 @@ __metadata:
   version: 1.0.1
   resolution: "min-indent@npm:1.0.1"
   checksum: bfc6dd03c5eaf623a4963ebd94d087f6f4bbbfd8c41329a7f09706b0cb66969c4ddd336abeb587bc44bc6f08e13bf90f0b374f9d71f9f01e04adc2cd6f083ef1
-  languageName: node
-  linkType: hard
-
-"mini-svg-data-uri@npm:^1.4.4":
-  version: 1.4.4
-  resolution: "mini-svg-data-uri@npm:1.4.4"
-  bin:
-    mini-svg-data-uri: cli.js
-  checksum: 997f1fbd8d59a70f03761e18626d335197a3479cb9d1ff75678e4b64b864d32a0b8fc18115eabde035e5299b8b4a354a78e57dd6ac10f9d604162a6170898d09
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
In #215, png imports were removed in order to make builds easier for projects importing the design system (by not requiring to support png files in their build systems, unless explicitly needed when using the map component). This change was a good step forward, but came at a bad time - breaking [app-frontend-react](https://github.com/Altinn/app-frontend-react/) at a very bad time. Now is the time to clean up and pay this debt, fixing app-frontend-react so the map component works properly - even with this change in the design system.

## Related Issue(s)
- #215 
- #216

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
