### PR TITLE
Add deprecation flag to moved components

### DIFF
--- a/.storybook/DeprecationWarning.tsx
+++ b/.storybook/DeprecationWarning.tsx
@@ -1,0 +1,19 @@
+import React, {ReactNode} from 'react';
+
+export interface DeprecationWarningProps {
+  children: ReactNode;
+}
+
+export const DeprecationWarning = ({ children }: DeprecationWarningProps) =>  (
+  <div
+    style={{
+      backgroundColor: '#f8d7da',
+      borderRadius: '0.25rem',
+      color: '#721c24',
+      marginBottom: '1rem',
+      padding: '1rem',
+    }}
+  >
+    <p style={{ margin: '0' }}><strong>Deprecated:</strong> {children}</p>
+  </div>
+);

--- a/.storybook/StoryPage.tsx
+++ b/.storybook/StoryPage.tsx
@@ -8,15 +8,18 @@ import {
   PRIMARY_STORY,
 } from '@storybook/addon-docs';
 import { AppWrapper } from '@/components/AppWrapper/AppWrapper';
+import {DeprecationWarning} from "@sb/DeprecationWarning";
 
 interface StoryPageProps {
   description: string; // supports markdown
+  deprecationWarning?: string;
 }
 
-export const StoryPage = ({ description }: StoryPageProps) => {
+export const StoryPage = ({ description, deprecationWarning }: StoryPageProps) => {
   return (
     <AppWrapper>
       <Title />
+      {deprecationWarning && <DeprecationWarning>{deprecationWarning}</DeprecationWarning>}
       <Description>{description}</Description>
       <Stories includePrimary={true} />
       <Heading>Props</Heading>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -39,6 +39,9 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   iconPlacement?: 'right' | 'left';
 }
 
+/*
+ * @deprecated Use Button from @digdir/design-system-react instead.
+ */
 const Button = (
   {
     children,

--- a/src/components/Button/Stories/FilledButton.stories.tsx
+++ b/src/components/Button/Stories/FilledButton.stories.tsx
@@ -30,6 +30,7 @@ export default {
       page: () => (
         <StoryPage
           description={`TODO: Add a description (supports markdown)`}
+          deprecationWarning={`Use Button from @digdir/design-system-react instead.`}
         />
       ),
     },

--- a/src/components/Button/Stories/OutlineButton.stories.tsx
+++ b/src/components/Button/Stories/OutlineButton.stories.tsx
@@ -30,6 +30,7 @@ export default {
       page: () => (
         <StoryPage
           description={`TODO: Add a description (supports markdown)`}
+          deprecationWarning={`Use Button from @digdir/design-system-react instead.`}
         />
       ),
     },

--- a/src/components/Button/Stories/QuietButton.stories.tsx
+++ b/src/components/Button/Stories/QuietButton.stories.tsx
@@ -30,6 +30,7 @@ export default {
       page: () => (
         <StoryPage
           description={`TODO: Add a description (supports markdown)`}
+          deprecationWarning={`Use Button from @digdir/design-system-react instead.`}
         />
       ),
     },

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -30,6 +30,7 @@ export default {
                         The component relies on being controlled, which means that it expects the consumer to set its \`checked\` state.
                         That is why the demonstration in Storybook does not change when clicking.
                         The \`onChange\` property must be set to trigger this change.`}
+          deprecationWarning={`Use Checkbox from @digdir/design-system-react instead.`}
         />
       ),
     },

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -24,6 +24,9 @@ export interface CheckboxProps {
   readOnly?: boolean;
 }
 
+/*
+ * @deprecated Use Checkbox from @digdir/design-system-react instead.
+ */
 export const Checkbox = ({
   checkboxId,
   checked,

--- a/src/components/CheckboxGroup/CheckboxGroup.stories.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.stories.tsx
@@ -30,6 +30,9 @@ export default {
             'Group of checkboxes for use cases where the user should be able to choose multiple answers from a list of given values. ' +
             "Its `onChange` prop can be set to a function that will be called with a list of the selected checkboxes' names each time something changes."
           }
+          deprecationWarning={
+            'Use CheckboxGroup from @digdir/design-system-react instead.'
+          }
         />
       ),
     },

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -53,6 +53,9 @@ const reducer = (state: CheckedNames, action: ReducerAction) => {
 const checkedItems = (items: CheckboxItem[]) =>
   items.filter(({ checked }) => checked).map(({ name }) => name);
 
+/*
+ * @deprecated Use CheckboxGroup from @digdir/design-system-react instead.
+ */
 export const CheckboxGroup = ({
   compact,
   description,

--- a/src/components/ErrorMessage/ErrorMessage.stories.tsx
+++ b/src/components/ErrorMessage/ErrorMessage.stories.tsx
@@ -29,6 +29,7 @@ export default {
           description={
             'Simple error-message suitable to be shown in table views'
           }
+          deprecationWarning={`Use ErrorMessage from @digdir/design-system-react instead.`}
         />
       ),
     },

--- a/src/components/ErrorMessage/ErrorMessage.tsx
+++ b/src/components/ErrorMessage/ErrorMessage.tsx
@@ -9,6 +9,9 @@ export interface ErrorMessageProps {
   ariaLabel?: string;
 }
 
+/*
+ * @deprecated Use ErrorMessage from @digdir/design-system-react instead.
+ */
 export const ErrorMessage = ({
   id,
   children,

--- a/src/components/FieldSet/FieldSet.stories.tsx
+++ b/src/components/FieldSet/FieldSet.stories.tsx
@@ -26,6 +26,7 @@ export default {
       page: () => (
         <StoryPage
           description={`Field set component to use as a wrapper for groups of form elements.`}
+          deprecationWarning={`Use FieldSet from @digdir/design-system-react instead.`}
         />
       ),
     },

--- a/src/components/FieldSet/FieldSet.tsx
+++ b/src/components/FieldSet/FieldSet.tsx
@@ -21,6 +21,9 @@ export enum FieldSetSize {
   Small = 'small',
 }
 
+/*
+ * @deprecated Use FieldSet from @digdir/design-system-react instead.
+ */
 export const FieldSet = ({
   children,
   className,

--- a/src/components/RadioButton/RadioButton.stories.tsx
+++ b/src/components/RadioButton/RadioButton.stories.tsx
@@ -32,6 +32,7 @@ export default {
                         We recommend using our \`RadioGroup\` component if you need radio buttons,
                         but this standalone component might be useful if \`RadioGroup\` doesn't match the layout criteria of your use case.
                         If that is the case, you may also consider contributing to the design system 🙂`}
+          deprecationWarning={`Use RadioButton from @digdir/design-system-react instead.`}
         />
       ),
     },

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -30,6 +30,9 @@ export interface RadioButtonProps {
   value: string;
 }
 
+/*
+ * @deprecated Use RadioButton from @digdir/design-system-react instead.
+ */
 export const RadioButton = ({
   checked,
   description,

--- a/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -29,6 +29,7 @@ export default {
           description={`Group of radio buttons for use cases where the user is supposed to select one and ony one value from a short list.
                         It behaves similarly to channel presets on radios, hence its name.
                         Its \`onChange\` property can be set to a function that will be called with the checked value each time it changes.`}
+          deprecationWarning={`Use RadioGroup from @digdir/design-system-react instead.`}
         />
       ),
     },

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -39,6 +39,9 @@ export interface RadioGroupProps {
   variant?: RadioGroupVariant;
 }
 
+/*
+ * @deprecated Use RadioGroup from @digdir/design-system-react instead.
+ */
 export const RadioGroup = ({
   description,
   disabled,

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -51,6 +51,9 @@ const eventListenerKeys = {
   Enter: 'Enter',
 };
 
+/*
+ * @deprecated Use Select from @digdir/design-system-react instead.
+ */
 export const Select = (props: SelectProps) => {
   const {
     disabled,

--- a/src/components/Select/Stories/MultipleSelect.stories.tsx
+++ b/src/components/Select/Stories/MultipleSelect.stories.tsx
@@ -46,6 +46,7 @@ export default {
       page: () => (
         <StoryPage
           description={`This is a select box with the possibility to choose multiple values, like \`<select multiple>\` in html. It has an \`onChange\` property hat accepts a function which will receive a list of the selected values each time it is changed.'`}
+          deprecationWarning={`Use Select from @digdir/design-system-react instead.`}
         />
       ),
     },

--- a/src/components/Select/Stories/SingleSelect.stories.tsx
+++ b/src/components/Select/Stories/SingleSelect.stories.tsx
@@ -27,6 +27,7 @@ export default {
       page: () => (
         <StoryPage
           description={`This is a select box. It only allows one option to be selected, like \`<select>\` in html. It has an \`onChange\` property hat accepts a function which will receive the selected value each time it is changed.`}
+          deprecationWarning={`Use Select from @digdir/design-system-react instead.`}
         />
       ),
     },

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -35,6 +35,7 @@ export default {
                         It is also possible to specify IDs for the tab and the panel components (they will be generated if not given).
                         The \`activeTab\` property can be used to define which tab should be selected by default. It defaults to the first tab.
                         The \`onChange\` property is optional and can be used to trigger some function when the user switches to another tab. It is called with the tab value as a parameter.`}
+          deprecationWarning={`Use Tabs from @digdir/design-system-react instead.`}
         />
       ),
     },

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -23,6 +23,9 @@ export interface TabsProps {
 
 const validId = (str: string) => str.replace(/\s/, '_');
 
+/*
+ * @deprecated Use Tabs from @digdir/design-system-react instead.
+ */
 export const Tabs = ({ activeTab, items, onChange }: TabsProps) => {
   const idBase = useId();
 


### PR DESCRIPTION
## Description
Added a new `DeprecationWarning` component to use within the Storybook documentation and added `@deprecated` flags to components that have been moved to the common design system.

## Related Issue(s)
- #235

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
