### PR TITLE
Fixed WCAG issue with focusable TableRow

### DIFF
--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -39,7 +39,6 @@ export function TableRow<T>({
 
   return (
     <tr
-      tabIndex={variantStandard === Variant.Body ? -1 : 0}
       {...tableRowProps}
       className={cn(
         classes.TableRow,


### PR DESCRIPTION
## Description
There's no reason that TableRow should be focusable by tabIndex as default because the content within TableRow will automatically be focusable if they are interactive elements. 

By removing the tabIndex we have the same tab-behaviour as material and bootstrap tables. 

## Related Issue(s)
- https://github.com/Altinn/app-frontend-react/issues/830

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
