### PR TITLE
Replace class names that collide with class names in Digdir's design system

### DIFF
--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -1,4 +1,4 @@
-.button {
+.altinn-button {
   --icon-size: var(--component-button-size-icon-small);
   --button-vertical-padding: var(--component-button-space-padding-x-small);
 
@@ -15,17 +15,17 @@
   justify-content: center;
 }
 
-.button:focus-visible {
+.altinn-button:focus-visible {
   outline: var(--interactive_components-colors-focus_outline) solid
     var(--border_width-standard);
   outline-offset: var(--border_width-standard);
 }
 
-.button:focus:not(:focus-visible) {
+.altinn-button:focus:not(:focus-visible) {
   outline: none;
 }
 
-.button:disabled {
+.altinn-button:disabled {
   cursor: auto;
   opacity: var(--interactive_components-colors-disabled-opacity);
 }
@@ -35,7 +35,7 @@
   width: var(--icon-size);
 }
 
-.button--small {
+.altinn-button--small {
   height: var(--component-button-size-height-small);
   font-size: var(--font_size-300);
   --icon-size: var(--component-button-size-icon-small);
@@ -43,7 +43,7 @@
   gap: var(--component-button-space-gap-small);
 }
 
-.button--medium {
+.altinn-button--medium {
   height: var(--component-button-size-height-medium);
   min-width: var(--component-button-size-height-medium);
   font-size: var(--font_size-400-breakpoint_md);
@@ -52,7 +52,7 @@
   gap: var(--component-button-space-gap-medium);
 }
 
-.button--large {
+.altinn-button--large {
   height: var(--component-button-size-height-large);
   min-width: var(--component-button-size-height-large);
   font-size: var(--font_size-600-breakpoint_md);
@@ -61,289 +61,289 @@
   gap: var(--component-button-space-gap-large);
 }
 
-.button--full-width {
+.altinn-button--full-width {
   width: 100%;
 }
 
-.button--dashed-border {
+.altinn-button--dashed-border {
   border-style: dashed;
 }
 
-.button--only-icon {
+.altinn-button--only-icon {
   padding: 0.5rem !important;
 }
 
-.button--filled {
+.altinn-button--filled {
   border-radius: 3px;
   color: var(--component-button-filled-color-text-all);
   fill: var(--component-button-filled-color-text-all);
 }
 
-.button--outline {
+.altinn-button--outline {
   border-radius: 3px;
   background-color: transparent;
 }
 
-.button--quiet {
+.altinn-button--quiet {
   border-radius: 50px;
   padding: 0 calc(var(--button-vertical-padding) * 2 / 3);
   background-color: transparent;
 }
 
 /* Filled button colors */
-.button--filled--primary {
+.altinn-button--filled--primary {
   background: var(--component-button-filled-primary-color-background-default);
 }
 
-.button--filled--primary:not(:disabled):hover {
+.altinn-button--filled--primary:not(:disabled):hover {
   background: var(--component-button-filled-primary-color-background-hover);
 }
 
-.button--filled--primary:not(:disabled):active {
+.altinn-button--filled--primary:not(:disabled):active {
   background: var(--component-button-filled-primary-color-background-pressed);
 }
 
-.button--filled--secondary {
+.altinn-button--filled--secondary {
   background: var(--component-button-filled-primary-color-background-pressed);
 }
 
-.button--filled--secondary:not(:disabled):hover {
+.altinn-button--filled--secondary:not(:disabled):hover {
   background: var(--colors-blue-800);
 }
 
-.button--filled--secondary:not(:disabled):active {
+.altinn-button--filled--secondary:not(:disabled):active {
   background: var(--colors-blue-950);
 }
 
-.button--filled--success {
+.altinn-button--filled--success {
   background: var(--component-button-filled-success-color-background-default);
 }
 
-.button--filled--success:not(:disabled):hover {
+.altinn-button--filled--success:not(:disabled):hover {
   background: var(--component-button-filled-success-color-background-hover);
 }
 
-.button--filled--success:not(:disabled):active {
+.altinn-button--filled--success:not(:disabled):active {
   background: var(--component-button-filled-success-color-background-pressed);
 }
 
-.button--filled--danger {
+.altinn-button--filled--danger {
   background: var(--component-button-filled-danger-color-background-default);
 }
 
-.button--filled--danger:not(:disabled):hover {
+.altinn-button--filled--danger:not(:disabled):hover {
   background: var(--component-button-filled-danger-color-background-hover);
 }
 
-.button--filled--danger:not(:disabled):active {
+.altinn-button--filled--danger:not(:disabled):active {
   background: var(--colors-red-800);
 }
 
-.button--filled--inverted {
+.altinn-button--filled--inverted {
   color: var(--colors-blue-900);
   fill: var(--colors-blue-900);
   background: var(--colors-white);
 }
 
-.button--filled--inverted:not(:disabled):hover {
+.altinn-button--filled--inverted:not(:disabled):hover {
   color: var(--colors-blue-900);
   fill: var(--colors-blue-900);
   background: rgba(255, 255, 255, 0.9);
 }
 
-.button--filled--inverted:not(:disabled):active {
+.altinn-button--filled--inverted:not(:disabled):active {
   color: var(--colors-white);
   fill: var(--colors-white);
   background: rgba(255, 255, 255, 0.1);
 }
 
-.button--filled--inverted:focus-visible {
+.altinn-button--filled--inverted:focus-visible {
   outline-color: var(--colors-white);
 }
 
 /* Outline button colors */
-.button--outline--primary {
+.altinn-button--outline--primary {
   color: var(--component-button-outline-primary-color-text-default);
   fill: var(--component-button-outline-primary-color-text-default);
   border-color: var(--component-button-outline-primary-color-border-default);
   background: var(--component-button-outline-primary-color-background-default);
 }
 
-.button--outline--primary:not(:disabled):hover {
+.altinn-button--outline--primary:not(:disabled):hover {
   color: var(--colors-blue-800);
   fill: var(--colors-blue-800);
   background: var(--component-button-outline-primary-color-background-hover);
   border-color: var(--component-button-outline-primary-color-border-hover);
 }
 
-.button--outline--primary:not(:disabled):active {
+.altinn-button--outline--primary:not(:disabled):active {
   color: var(--component-button-outline-primary-color-text-pressed);
   fill: var(--component-button-outline-primary-color-text-pressed);
   background: var(--component-button-outline-primary-color-background-pressed);
 }
 
-.button--outline--secondary {
+.altinn-button--outline--secondary {
   color: var(--colors-blue-900);
   fill: var(--colors-blue-900);
   background: var(--colors-white);
   border-color: var(--colors-blue-900);
 }
 
-.button--outline--secondary:not(:disabled):hover {
+.altinn-button--outline--secondary:not(:disabled):hover {
   background: var(--colors-blue-200);
 }
 
-.button--outline--secondary:not(:disabled):active {
+.altinn-button--outline--secondary:not(:disabled):active {
   color: var(--colors-white);
   fill: var(--colors-white);
   background: var(--colors-blue-900);
 }
 
-.button--outline--success {
+.altinn-button--outline--success {
   color: var(--colors-green-700);
   fill: var(--colors-green-700);
   background: var(--colors-white);
   border-color: var(--colors-green-700);
 }
 
-.button--outline--success:not(:disabled):hover {
+.altinn-button--outline--success:not(:disabled):hover {
   color: var(--colors-green-800);
   fill: var(--colors-green-800);
   background: var(--colors-green-300);
 }
 
-.button--outline--success:not(:disabled):active {
+.altinn-button--outline--success:not(:disabled):active {
   color: var(--colors-white);
   fill: var(--colors-white);
   background: var(--colors-green-700);
 }
 
-.button--outline--danger {
+.altinn-button--outline--danger {
   color: var(--colors-red-500);
   fill: var(--colors-red-500);
   background: var(--colors-white);
   border-color: var(--colors-red-500);
 }
 
-.button--outline--danger:not(:disabled):hover {
+.altinn-button--outline--danger:not(:disabled):hover {
   color: var(--colors-red-700);
   fill: var(--colors-red-700);
   background: var(--colors-red-200);
   border-color: var(--colors-red-700);
 }
 
-.button--outline--danger:not(:disabled):active {
+.altinn-button--outline--danger:not(:disabled):active {
   color: var(--colors-white);
   fill: var(--colors-white);
   background: var(--colors-red-500);
 }
 
-.button--outline--inverted {
+.altinn-button--outline--inverted {
   color: var(--colors-white);
   fill: var(--colors-white);
   border-color: var(--colors-white);
   background: transparent;
 }
 
-.button--outline--inverted:not(:disabled):hover {
+.altinn-button--outline--inverted:not(:disabled):hover {
   background: rgba(255, 255, 255, 0.1);
 }
 
-.button--outline--inverted:not(:disabled):active {
+.altinn-button--outline--inverted:not(:disabled):active {
   color: var(--colors-blue-900);
   fill: var(--colors-blue-900);
   background: var(--colors-white);
 }
 
-.button--outline--inverted:focus-visible {
+.altinn-button--outline--inverted:focus-visible {
   outline-color: var(--colors-white);
 }
 
 /* Quiet button colors */
-.button--quiet--primary {
+.altinn-button--quiet--primary {
   color: var(--component-button-quiet-primary-color-text-default);
   fill: var(--component-button-quiet-primary-color-text-default);
 }
 
-.button--quiet--primary:not(:disabled):hover {
+.altinn-button--quiet--primary:not(:disabled):hover {
   color: var(--colors-blue-800);
   fill: var(--colors-blue-800);
   background: var(--component-button-quiet-primary-color-background-hover);
 }
 
-.button--quiet--primary:not(:disabled):active {
+.altinn-button--quiet--primary:not(:disabled):active {
   color: var(--component-button-filled-color-text-all);
   fill: var(--component-button-filled-color-text-all);
   background: var(--component-button-quiet-primary-color-background-pressed);
 }
 
-.button--quiet--secondary {
+.altinn-button--quiet--secondary {
   color: var(--colors-blue-900);
   fill: var(--colors-blue-900);
 }
 
-.button--quiet--secondary:not(:disabled):hover {
+.altinn-button--quiet--secondary:not(:disabled):hover {
   background: var(--colors-neutral-400);
 }
 
-.button--quiet--secondary:not(:disabled):active {
+.altinn-button--quiet--secondary:not(:disabled):active {
   color: var(--component-button-filled-color-text-all);
   fill: var(--component-button-filled-color-text-all);
   background: var(--colors-blue-900);
 }
 
-.button--quiet--success {
+.altinn-button--quiet--success {
   color: var(--colors-green-700);
   fill: var(--colors-green-700);
 }
 
-.button--quiet--success:not(:disabled):hover {
+.altinn-button--quiet--success:not(:disabled):hover {
   color: var(--colors-green-800);
   fill: var(--colors-green-800);
   background: var(--colors-green-300);
 }
 
-.button--quiet--success:not(:disabled):active {
+.altinn-button--quiet--success:not(:disabled):active {
   color: var(--component-button-filled-color-text-all);
   fill: var(--component-button-filled-color-text-all);
   background: var(--colors-green-900);
 }
 
-.button--quiet--danger {
+.altinn-button--quiet--danger {
   color: var(--colors-red-600);
   fill: var(--colors-red-600);
 }
 
-.button--quiet--danger:not(:disabled):hover {
+.altinn-button--quiet--danger:not(:disabled):hover {
   color: var(--colors-red-800);
   fill: var(--colors-red-800);
   background: var(--colors-red-200);
 }
 
-.button--quiet--danger:not(:disabled):active {
+.altinn-button--quiet--danger:not(:disabled):active {
   color: var(--component-button-filled-color-text-all);
   fill: var(--component-button-filled-color-text-all);
   background: var(--colors-red-800);
 }
 
-.button--quiet--inverted {
+.altinn-button--quiet--inverted {
   color: var(--colors-white);
   fill: var(--colors-white);
   background: transparent;
 }
 
-.button--quiet--inverted:not(:disabled):hover {
+.altinn-button--quiet--inverted:not(:disabled):hover {
   color: var(--colors-blue-900);
   fill: var(--colors-blue-900);
   background: rgba(255, 255, 255, 0.9);
 }
 
-.button--quiet--inverted:not(:disabled):active {
+.altinn-button--quiet--inverted:not(:disabled):active {
   color: var(--colors-blue-900);
   fill: var(--colors-blue-900);
   background: var(--colors-white);
 }
 
-.button--quiet--inverted:focus-visible {
+.altinn-button--quiet--inverted:focus-visible {
   outline-color: var(--colors-white);
 }

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -14,10 +14,10 @@ describe('Button', () => {
     render({ variant: undefined });
     const button = screen.getByRole('button');
 
-    expect(button.classList.contains('button--primary')).toBe(true);
-    expect(button.classList.contains('button--secondary')).toBe(false);
-    expect(button.classList.contains('button--submit')).toBe(false);
-    expect(button.classList.contains('button--cancel')).toBe(false);
+    expect(button.classList.contains('altinn-button--primary')).toBe(true);
+    expect(button.classList.contains('altinn-button--secondary')).toBe(false);
+    expect(button.classList.contains('altinn-button--submit')).toBe(false);
+    expect(button.classList.contains('altinn-button--cancel')).toBe(false);
   });
 
   Object.values(ButtonVariant).forEach((variant) => {
@@ -29,9 +29,9 @@ describe('Button', () => {
 
       const button = screen.getByRole('button');
 
-      expect(button.classList.contains(`button--${variant}`)).toBe(true);
+      expect(button.classList.contains(`altinn-button--${variant}`)).toBe(true);
       otherVariants.forEach((v) => {
-        expect(button.classList.contains(`button--${v}`)).toBe(false);
+        expect(button.classList.contains(`altinn-button--${v}`)).toBe(false);
       });
     });
   });
@@ -45,9 +45,9 @@ describe('Button', () => {
 
       const button = screen.getByRole('button');
 
-      expect(button.classList.contains(`button--${color}`)).toBe(true);
+      expect(button.classList.contains(`altinn-button--${color}`)).toBe(true);
       otherVariants.forEach((c) => {
-        expect(button.classList.contains(`button--${c}`)).toBe(false);
+        expect(button.classList.contains(`altinn-button--${c}`)).toBe(false);
       });
     });
   });
@@ -59,9 +59,9 @@ describe('Button', () => {
 
       const button = screen.getByRole('button');
 
-      expect(button.classList.contains(`button--${size}`)).toBe(true);
+      expect(button.classList.contains(`altinn-button--${size}`)).toBe(true);
       otherVariants.forEach((s) => {
-        expect(button.classList.contains(`button--${s}`)).toBe(false);
+        expect(button.classList.contains(`altinn-button--${s}`)).toBe(false);
       });
     });
   });

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -63,14 +63,14 @@ const Button = (
       {...restHTMLProps}
       ref={ref}
       className={cn(
-        classes.button,
-        classes[`button--${size}`],
-        classes[`button--${variant}`],
-        classes[`button--${color}`],
-        classes[`button--${variant}--${color}`],
-        { [classes['button--full-width']]: fullWidth },
-        { [classes['button--dashed-border']]: dashedBorder },
-        { [classes[`button--only-icon`]]: !children && icon },
+        classes['altinn-button'],
+        classes[`altinn-button--${size}`],
+        classes[`altinn-button--${variant}`],
+        classes[`altinn-button--${color}`],
+        classes[`altinn-button--${variant}--${color}`],
+        { [classes['altinn-button--full-width']]: fullWidth },
+        { [classes['altinn-button--dashed-border']]: dashedBorder },
+        { [classes[`altinn-button--only-icon`]]: !children && icon },
         className,
       )}
       type={type}

--- a/src/components/Checkbox/Checkbox.module.css
+++ b/src/components/Checkbox/Checkbox.module.css
@@ -1,4 +1,4 @@
-.checkbox {
+.altinn-checkbox {
   /* Internal variables */
   --checkbox-background_color: var(
     --component-checkbox-color-background-default
@@ -15,46 +15,53 @@
   --input_box-border_radius: var(--checkbox-border_radius);
 }
 
-.checkbox--compact {
+.altinn-checkbox--compact {
   --checkbox-border_width: var(--component-checkbox-border_width-xsmall);
   --checkbox-height: var(--component-checkbox-size-height-xsmall);
   --checkbox-width: var(--component-checkbox-size-width-xsmall);
 }
 
-.checkbox--error {
+.altinn-checkbox--error {
   --checkbox-background_color: var(--component-checkbox-color-background-error);
   --checkbox-border_color: var(--component-checkbox-color-border-error);
 }
 
-.checkbox--checked {
+.altinn-checkbox--checked {
   --checkbox-checkmark-display: inline-block;
 }
 
-.checkbox--checked:not(.checkbox--disabled) {
+.altinn-checkbox--checked:not(.altinn-checkbox--disabled) {
   --checkbox-background_color: var(
     --component-checkbox-color-background-checked
   );
   --checkbox-border_color: var(--component-checkbox-color-border-checked);
 }
 
-.checkbox:not(.checkbox--disabled, .checkbox--checked):hover {
+.altinn-checkbox:not(
+    .altinn-checkbox--disabled,
+    .altinn-checkbox--checked
+  ):hover {
   --checkbox-background_color: var(--component-checkbox-color-background-hover);
 }
 
-.checkbox:not(.checkbox--disabled, .checkbox--error, .checkbox--checked):hover {
+.altinn-checkbox:not(
+    .altinn-checkbox--disabled,
+    .altinn-checkbox--error,
+    .altinn-checkbox--checked
+  ):hover {
   --checkbox-border_color: var(--component-checkbox-color-border-hover);
 }
 
-.checkbox--disabled.checkbox--checked {
+.altinn-checkbox--disabled.altinn-checkbox--checked {
   --checkbox-background_color: var(--component-checkbox-color-border-disabled);
   --checkbox-border_color: transparent;
 }
 
-.checkbox--read-only {
+.altinn-checkbox--read-only {
   --cursor: auto;
 }
 
-.visible-box {
+.altinn-visible-box {
   background-color: var(--checkbox-background_color);
   border-color: var(--checkbox-border_color);
   border-radius: var(--checkbox-border_radius);
@@ -66,7 +73,7 @@
   width: var(--checkbox-width);
 }
 
-.visible-box__checkmark {
+.altinn-visible-box__checkmark {
   background-color: white;
   clip-path: polygon(
     47.11% 56.51%,

--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -112,7 +112,7 @@ const render = (props: Partial<CheckboxProps> = {}) => {
 
 const renderAndGetWrapper = (props: Partial<CheckboxProps> = {}): Element => {
   const { container } = render(props);
-  const wrapper = container.querySelector('.checkbox');
+  const wrapper = container.querySelector('.altinn-checkbox');
   assert(wrapper !== null);
   return wrapper;
 };

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -44,12 +44,12 @@ export const Checkbox = ({
   <CheckboxRadioTemplate
     checked={checked}
     className={cn(
-      classes.checkbox,
-      checked && classes['checkbox--checked'],
-      error && classes['checkbox--error'],
-      disabled && classes['checkbox--disabled'],
-      compact && classes['checkbox--compact'],
-      readOnly && classes['checkbox--read-only'],
+      classes['altinn-checkbox'],
+      checked && classes['altinn-checkbox--checked'],
+      error && classes['altinn-checkbox--error'],
+      disabled && classes['altinn-checkbox--disabled'],
+      compact && classes['altinn-checkbox--compact'],
+      readOnly && classes['altinn-checkbox--read-only'],
     )}
     description={description}
     disabled={disabled}
@@ -67,8 +67,8 @@ export const Checkbox = ({
     }
     type='checkbox'
   >
-    <span className={classes['visible-box']}>
-      <span className={classes['visible-box__checkmark']} />
+    <span className={classes['altinn-visible-box']}>
+      <span className={classes['altinn-visible-box__checkmark']} />
     </span>
   </CheckboxRadioTemplate>
 );

--- a/src/components/CheckboxGroup/CheckboxGroup.module.css
+++ b/src/components/CheckboxGroup/CheckboxGroup.module.css
@@ -1,4 +1,4 @@
-.checkbox-group {
+.altinn-checkbox-group {
   --gap-x: var(--component-checkbox-group-space-gap-x-small);
   --gap-y: var(--component-checkbox-group-space-gap-y-small);
 
@@ -8,15 +8,15 @@
   row-gap: var(--gap-y);
 }
 
-.checkbox-group--compact {
+.altinn-checkbox-group--compact {
   --gap-x: var(--component-checkbox-group-space-gap-x-xsmall);
   --gap-y: var(--component-checkbox-group-space-gap-y-xsmall);
 }
 
-.checkbox-group--vertical {
+.altinn-checkbox-group--vertical {
   flex-direction: column;
 }
 
-.checkbox-group--horizontal {
+.altinn-checkbox-group--horizontal {
   flex-direction: row;
 }

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -97,9 +97,9 @@ export const CheckboxGroup = ({
     >
       <div
         className={cn(
-          classes['checkbox-group'],
-          classes[`checkbox-group--${variant}`],
-          compact && classes['checkbox-group--compact'],
+          classes['altinn-checkbox-group'],
+          classes[`altinn-checkbox-group--${variant}`],
+          compact && classes['altinn-checkbox-group--compact'],
         )}
       >
         {items.map((item) => (

--- a/src/components/ErrorMessage/ErrorMessage.module.css
+++ b/src/components/ErrorMessage/ErrorMessage.module.css
@@ -1,4 +1,4 @@
-.error-message-wrapper {
+.altinn-error-message-wrapper {
   color: var(--component-error_message-color-text);
   font-size: var(--component-error_message-font_size-xs);
 }

--- a/src/components/ErrorMessage/ErrorMessage.tsx
+++ b/src/components/ErrorMessage/ErrorMessage.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import cn from 'classnames';
 
 import classes from './ErrorMessage.module.css';
 
@@ -23,7 +22,7 @@ export const ErrorMessage = ({
       aria-label={ariaLabel}
       id={id}
       role='alertdialog'
-      className={cn(classes['error-message-wrapper'])}
+      className={classes['altinn-error-message-wrapper']}
     >
       {children}
     </div>

--- a/src/components/FieldSet/FieldSet.module.css
+++ b/src/components/FieldSet/FieldSet.module.css
@@ -1,4 +1,4 @@
-.field-set {
+.altinn-field-set {
   --color: var(--component-checkbox-color-text-default);
   --content-margin_top: var(--component-fieldset-space-gap-y-small);
   --description-color: var(--component-field_description-color-text-default);
@@ -14,39 +14,39 @@
   padding: 0;
 }
 
-.field-set--xsmall {
+.altinn-field-set--xsmall {
   --content-margin_top: var(--component-fieldset-space-gap-y-xsmall);
   --description-margin_top: var(--component-field_description-space-top-xsmall);
   --error_message-margin_top: var(--component-fieldset-space-gap-y-xsmall);
   --font_size: var(--component-checkbox-font_size-xs);
 }
 
-.field-set:disabled {
+.altinn-field-set:disabled {
   opacity: var(--interactive_components-colors-disabled-opacity);
 }
 
-.field-set:disabled * {
+.altinn-field-set:disabled * {
   opacity: 1;
 }
 
-.field-set__legend {
+.altinn-field-set__legend {
   font-weight: bold;
   padding: 0;
 }
 
-.field-set__description {
+.altinn-field-set__description {
   color: var(--description-color);
   margin: 0;
 }
 
-.field-set__legend + .field-set__description {
+.altinn-field-set__legend + .altinn-field-set__description {
   margin-top: var(--description-margin_top);
 }
 
-.field-set__content:not(:first-child) {
+.altinn-field-set__content:not(:first-child) {
   margin-top: var(--content-margin_top);
 }
 
-.field-set__error-message {
+.altinn-field-set__error-message {
   margin-top: var(--error_message-margin_top);
 }

--- a/src/components/FieldSet/FieldSet.test.tsx
+++ b/src/components/FieldSet/FieldSet.test.tsx
@@ -34,7 +34,7 @@ describe('FieldSet', () => {
     const description = 'Lorem ipsum dolor sit amet.';
     const { container } = render({ description });
     expect(
-      container.querySelector('.field-set__description'),
+      container.querySelector('.altinn-field-set__description'),
     ).toHaveTextContent(description);
   });
 
@@ -47,26 +47,32 @@ describe('FieldSet', () => {
     const error = 'Something is wrong.';
     const { container } = render({ error });
     expect(
-      container.querySelector('.field-set__error-message'),
+      container.querySelector('.altinn-field-set__error-message'),
     ).toHaveTextContent(error);
   });
 
   it('Should have class "field-set--small" by default', () => {
     render();
-    expect(screen.getByRole('group')).toHaveClass('field-set--small');
-    expect(screen.getByRole('group')).not.toHaveClass('field-set--xsmall');
+    expect(screen.getByRole('group')).toHaveClass('altinn-field-set--small');
+    expect(screen.getByRole('group')).not.toHaveClass(
+      'altinn-field-set--xsmall',
+    );
   });
 
   it('Should have class "field-set--small" if the "size" property is set to "small"', () => {
     render({ size: FieldSetSize.Small });
-    expect(screen.getByRole('group')).toHaveClass('field-set--small');
-    expect(screen.getByRole('group')).not.toHaveClass('field-set--xsmall');
+    expect(screen.getByRole('group')).toHaveClass('altinn-field-set--small');
+    expect(screen.getByRole('group')).not.toHaveClass(
+      'altinn-field-set--xsmall',
+    );
   });
 
   it('Should have class "field-set--xsmall" if the "size" property is set to "xsmall"', () => {
     render({ size: FieldSetSize.Xsmall });
-    expect(screen.getByRole('group')).toHaveClass('field-set--xsmall');
-    expect(screen.getByRole('group')).not.toHaveClass('field-set--small');
+    expect(screen.getByRole('group')).toHaveClass('altinn-field-set--xsmall');
+    expect(screen.getByRole('group')).not.toHaveClass(
+      'altinn-field-set--small',
+    );
   });
 
   it('Should be enabled by default', () => {

--- a/src/components/FieldSet/FieldSet.tsx
+++ b/src/components/FieldSet/FieldSet.tsx
@@ -36,21 +36,25 @@ export const FieldSet = ({
   return (
     <fieldset
       className={cn(
-        classes['field-set'],
-        classes[`field-set--${size}`],
+        classes['altinn-field-set'],
+        classes[`altinn-field-set--${size}`],
         className,
       )}
       disabled={disabled}
     >
       {legend && (
-        <legend className={classes['field-set__legend']}>{legend}</legend>
+        <legend className={classes['altinn-field-set__legend']}>
+          {legend}
+        </legend>
       )}
       {description && (
-        <p className={classes['field-set__description']}>{description}</p>
+        <p className={classes['altinn-field-set__description']}>
+          {description}
+        </p>
       )}
-      <div className={classes['field-set__content']}>{children}</div>
+      <div className={classes['altinn-field-set__content']}>{children}</div>
       {error && (
-        <div className={classes['field-set__error-message']}>
+        <div className={classes['altinn-field-set__error-message']}>
           <ErrorMessage>{error}</ErrorMessage>
         </div>
       )}

--- a/src/components/RadioButton/RadioButton.module.css
+++ b/src/components/RadioButton/RadioButton.module.css
@@ -1,4 +1,4 @@
-.radio {
+.altinn-radio {
   /* Internal variables */
   --radio-background_color: var(--component-checkbox-color-background-default);
   --radio-border_color: var(--component-checkbox-color-border-default);
@@ -12,41 +12,45 @@
   --input_box-size: var(--radio-size);
 }
 
-.radio--small {
+.altinn-radio--small {
   --radio-size: var(--component-checkbox-size-width-small);
 }
 
-.radio--xsmall {
+.altinn-radio--xsmall {
   --radio-size: var(--component-checkbox-size-width-xsmall);
 }
 
-.radio--error {
+.altinn-radio--error {
   --radio-background_color: var(--component-checkbox-color-background-error);
   --radio-border_color: var(--component-checkbox-color-border-error);
 }
 
-.radio--checked {
+.altinn-radio--checked {
   --radio-checkmark-display: inline-block;
 }
 
-.radio--checked:not(.radio--disabled, .radio--error) {
+.altinn-radio--checked:not(.altinn-radio--disabled, .altinn-radio--error) {
   --radio-border_color: var(--component-checkbox-color-border-checked);
 }
 
-.radio:not(.radio--disabled, .radio--checked):hover {
+.altinn-radio:not(.altinn-radio--disabled, .altinn-radio--checked):hover {
   --radio-background_color: var(--component-checkbox-color-background-hover);
 }
 
-.radio:not(.radio--disabled, .radio--error, .radio--checked):hover {
+.altinn-radio:not(
+    .altinn-radio--disabled,
+    .altinn-radio--error,
+    .altinn-radio--checked
+  ):hover {
   --radio-border_color: var(--component-checkbox-color-border-hover);
 }
 
-.radio--disabled.radio--checked {
+.altinn-radio--disabled.altinn-radio--checked {
   --radio-background_color: var(--component-checkbox-color-border-disabled);
   --radio-border_color: transparent;
 }
 
-.visible-button {
+.altinn-visible-button {
   background-color: var(--radio-background_color);
   border-color: var(--radio-border_color);
   border-radius: 50%;
@@ -58,7 +62,7 @@
   width: var(--radio-size);
 }
 
-.visible-button__checkmark {
+.altinn-visible-button__checkmark {
   --radio-checkmark-size: 80%;
   background-color: var(--radio-checkmark-color);
   border-radius: 50%;

--- a/src/components/RadioButton/RadioButton.test.tsx
+++ b/src/components/RadioButton/RadioButton.test.tsx
@@ -31,19 +31,19 @@ describe('RadioButton', () => {
   it('Is not checked by default', () => {
     const wrapper = renderAndGetWrapper();
     expect(screen.getByRole('radio')).not.toBeChecked();
-    expect(wrapper).not.toHaveClass('radio--checked');
+    expect(wrapper).not.toHaveClass('altinn-radio--checked');
   });
 
   it('Is checked if the "checked" prop is true', () => {
     const wrapper = renderAndGetWrapper({ checked: true });
     expect(screen.getByRole('radio')).toBeChecked();
-    expect(wrapper).toHaveClass('radio--checked');
+    expect(wrapper).toHaveClass('altinn-radio--checked');
   });
 
   it('Is not checked if the "checked" prop is false', () => {
     const wrapper = renderAndGetWrapper({ checked: false });
     expect(screen.getByRole('radio')).not.toBeChecked();
-    expect(wrapper).not.toHaveClass('radio--checked');
+    expect(wrapper).not.toHaveClass('altinn-radio--checked');
   });
 
   it('Calls onChange when user clicks', async () => {
@@ -90,39 +90,39 @@ describe('RadioButton', () => {
 
   it('Renders with correct classes by default', () => {
     const wrapper = renderAndGetWrapper();
-    expect(wrapper).toHaveClass('radio--small');
-    expect(wrapper).not.toHaveClass('radio--error');
-    expect(wrapper).not.toHaveClass('radio--disabled');
+    expect(wrapper).toHaveClass('altinn-radio--small');
+    expect(wrapper).not.toHaveClass('altinn-radio--error');
+    expect(wrapper).not.toHaveClass('altinn-radio--disabled');
   });
 
   it('Renders with "xsmall" size class by if size is set to "Xsmall"', () => {
     const wrapper = renderAndGetWrapper({ size: RadioButtonSize.Xsmall });
-    expect(wrapper).toHaveClass('radio--xsmall');
+    expect(wrapper).toHaveClass('altinn-radio--xsmall');
   });
 
   it('Renders with "small" size class by if size is set to "Small"', () => {
     const wrapper = renderAndGetWrapper({ size: RadioButtonSize.Small });
-    expect(wrapper).toHaveClass('radio--small');
+    expect(wrapper).toHaveClass('altinn-radio--small');
   });
 
   it('Renders with "error" class if the "error" property is true', () => {
     const wrapper = renderAndGetWrapper({ error: true });
-    expect(wrapper).toHaveClass('radio--error');
+    expect(wrapper).toHaveClass('altinn-radio--error');
   });
 
   it('Renders withot "error" class if the "error" property is false', () => {
     const wrapper = renderAndGetWrapper({ error: false });
-    expect(wrapper).not.toHaveClass('radio--error');
+    expect(wrapper).not.toHaveClass('altinn-radio--error');
   });
 
   it('Renders with "disabled" class if the "disabled" property is true', () => {
     const wrapper = renderAndGetWrapper({ disabled: true });
-    expect(wrapper).toHaveClass('radio--disabled');
+    expect(wrapper).toHaveClass('altinn-radio--disabled');
   });
 
   it('Renders without "disabled" class if the "disabled" property is false', () => {
     const wrapper = renderAndGetWrapper({ disabled: false });
-    expect(wrapper).not.toHaveClass('radio--disabled');
+    expect(wrapper).not.toHaveClass('altinn-radio--disabled');
   });
 
   it.each([false, undefined])(
@@ -160,7 +160,7 @@ const renderAndGetWrapper = (
   props: Partial<RadioButtonProps> = {},
 ): Element => {
   const { container } = render(props);
-  const wrapper = container.querySelector('.radio');
+  const wrapper = container.querySelector('.altinn-radio');
   assert(wrapper !== null);
   return wrapper;
 };

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -50,11 +50,11 @@ export const RadioButton = ({
   <CheckboxRadioTemplate
     checked={checked}
     className={cn(
-      classes.radio,
-      classes[`radio--${size}`],
-      checked && classes['radio--checked'],
-      error && classes['radio--error'],
-      disabled && classes['radio--disabled'],
+      classes['altinn-radio'],
+      classes[`altinn-radio--${size}`],
+      checked && classes['altinn-radio--checked'],
+      error && classes['altinn-radio--error'],
+      disabled && classes['altinn-radio--disabled'],
     )}
     description={description}
     disabled={disabled}
@@ -72,8 +72,8 @@ export const RadioButton = ({
     type='radio'
     value={value}
   >
-    <span className={classes['visible-button']}>
-      <span className={classes['visible-button__checkmark']} />
+    <span className={classes['altinn-visible-button']}>
+      <span className={classes['altinn-visible-button__checkmark']} />
     </span>
   </CheckboxRadioTemplate>
 );

--- a/src/components/RadioGroup/RadioGroup.module.css
+++ b/src/components/RadioGroup/RadioGroup.module.css
@@ -1,24 +1,24 @@
-.radio-group {
+.altinn-radio-group {
   column-gap: var(--gap-x);
   display: flex;
   flex-wrap: wrap;
   row-gap: var(--gap-y);
 }
 
-.radio-group--xsmall {
+.altinn-radio-group--xsmall {
   --gap-x: var(--component-checkbox-group-space-gap-x-xsmall);
   --gap-y: var(--component-checkbox-group-space-gap-y-xsmall);
 }
 
-.radio-group--small {
+.altinn-radio-group--small {
   --gap-x: var(--component-checkbox-group-space-gap-x-small);
   --gap-y: var(--component-checkbox-group-space-gap-y-small);
 }
 
-.radio-group--vertical {
+.altinn-radio-group--vertical {
   flex-direction: column;
 }
 
-.radio-group--horizontal {
+.altinn-radio-group--horizontal {
   flex-direction: row;
 }

--- a/src/components/RadioGroup/RadioGroup.test.tsx
+++ b/src/components/RadioGroup/RadioGroup.test.tsx
@@ -180,31 +180,37 @@ describe('RadioGroup', () => {
   it('Renders with "vertical" variant class and "small" size classname by default', () => {
     render();
     expect(screen.getByRole('radiogroup')).toHaveClass(
-      'radio-group--vertical',
-      'radio-group--small',
+      'altinn-radio-group--vertical',
+      'altinn-radio-group--small',
     );
   });
 
   it('Renders with "vertical" variant class if variant is set to "Vertical"', () => {
     render({ variant: RadioGroupVariant.Vertical });
-    expect(screen.getByRole('radiogroup')).toHaveClass('radio-group--vertical');
+    expect(screen.getByRole('radiogroup')).toHaveClass(
+      'altinn-radio-group--vertical',
+    );
   });
 
   it('Renders with "horizontal" variant class if variant is set to "Horizontal"', () => {
     render({ variant: RadioGroupVariant.Horizontal });
     expect(screen.getByRole('radiogroup')).toHaveClass(
-      'radio-group--horizontal',
+      'altinn-radio-group--horizontal',
     );
   });
 
   it('Renders with "xsmall" size class if size is set to "Xsmall"', () => {
     render({ size: RadioGroupSize.Xsmall });
-    expect(screen.getByRole('radiogroup')).toHaveClass('radio-group--xsmall');
+    expect(screen.getByRole('radiogroup')).toHaveClass(
+      'altinn-radio-group--xsmall',
+    );
   });
 
   it('Renders with "small" size class if size is set to "Small"', () => {
     render({ size: RadioGroupSize.Small });
-    expect(screen.getByRole('radiogroup')).toHaveClass('radio-group--small');
+    expect(screen.getByRole('radiogroup')).toHaveClass(
+      'altinn-radio-group--small',
+    );
   });
 
   it('Renders all radio buttons with presentation role when the "presentation" property is true', () => {
@@ -230,12 +236,12 @@ const getWrapper = (index: number) => document.querySelectorAll('label')[index];
 
 const expectChecked = (index: number) => {
   expect(getRadioButton(index)).toBeChecked();
-  expect(getWrapper(index)).toHaveClass('radio--checked');
+  expect(getWrapper(index)).toHaveClass('altinn-radio--checked');
 };
 
 const expectNotChecked = (index: number) => {
   expect(getRadioButton(index)).not.toBeChecked();
-  expect(getWrapper(index)).not.toHaveClass('radio--checked');
+  expect(getWrapper(index)).not.toHaveClass('altinn-radio--checked');
 };
 
 const expectOneChecked = (index: number) => {

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -92,9 +92,9 @@ export const RadioGroup = ({
     >
       <div
         className={[
-          classes['radio-group'],
-          classes[`radio-group--${variant}`],
-          classes[`radio-group--${size}`],
+          classes['altinn-radio-group'],
+          classes[`altinn-radio-group--${variant}`],
+          classes[`altinn-radio-group--${size}`],
         ].join(' ')}
         role={presentation ? undefined : 'radiogroup'}
       >

--- a/src/components/Select/MultiSelectItem.module.css
+++ b/src/components/Select/MultiSelectItem.module.css
@@ -1,4 +1,4 @@
-.multi-select-item {
+.altinn-multi-select-item {
   --border-radius: calc(var(--multiselect_item-height) / 2);
   align-items: center;
   background-color: var(--multiselect_item-background_color);
@@ -11,7 +11,7 @@
   padding-left: var(--multiselect_item-space_left);
 }
 
-.multi-select-item__delete-button {
+.altinn-multi-select-item__delete-button {
   background-color: transparent;
   border-bottom-right-radius: inherit;
   border-top-right-radius: inherit;
@@ -24,16 +24,16 @@
   width: var(--multiselect_item-height);
 }
 
-.multi-select-item__delete-button:not(:disabled):hover {
+.altinn-multi-select-item__delete-button:not(:disabled):hover {
   background-color: var(--delete_cross_box-color-hover);
 }
 
-.multi-select-item__delete-button:focus-visible {
+.altinn-multi-select-item__delete-button:focus-visible {
   background-color: var(--delete_cross_box-color-hover);
   outline: var(--focus_visible-outline);
 }
 
-.multi-select-item__delete-button__cross {
+.altinn-multi-select-item__delete-button__cross {
   background-color: var(--multiselect_item_delete_cross-color);
   clip-path: var(--delete_cross-clip_path);
   display: inline-block;

--- a/src/components/Select/MultiSelectItem.tsx
+++ b/src/components/Select/MultiSelectItem.tsx
@@ -15,15 +15,17 @@ export const MultiSelectItem = ({
   onDeleteButtonClick,
   label,
 }: MultiSelectItemProps) => (
-  <span className={classes['multi-select-item']}>
+  <span className={classes['altinn-multi-select-item']}>
     <span>{label}</span>
     <button
       aria-label={deleteButtonLabel}
-      className={classes['multi-select-item__delete-button']}
+      className={classes['altinn-multi-select-item__delete-button']}
       disabled={disabled}
       onClick={onDeleteButtonClick}
     >
-      <span className={classes['multi-select-item__delete-button__cross']} />
+      <span
+        className={classes['altinn-multi-select-item__delete-button__cross']}
+      />
     </button>
   </span>
 );

--- a/src/components/Select/Select.module.css
+++ b/src/components/Select/Select.module.css
@@ -1,4 +1,4 @@
-.select {
+.altinn-select {
   --delete_cross_box-border_radius: var(
     --interactive_components-border_radius-normal
   );
@@ -72,24 +72,24 @@
   position: relative;
 }
 
-.select--disabled {
+.altinn-select--disabled {
   --interactive_element-cursor: auto;
   opacity: var(--interactive_components-colors-disabled-opacity);
 }
 
-.select--expanded {
+.altinn-select--expanded {
   --delete_cross-color: var(--delete_cross-color-active);
 }
 
-.select:not(.select--expanded) .select__option-list {
+.altinn-select:not(.altinn-select--expanded) .altinn-select__option-list {
   display: none;
 }
 
-.select--using-keyboard {
+.altinn-select--using-keyboard {
   --option-outline-focus: var(--focus_visible-outline);
 }
 
-.select__field__button {
+.altinn-select__field__button {
   background: transparent;
   border: 0;
   cursor: var(--interactive_element-cursor);
@@ -98,13 +98,13 @@
   padding: 0;
 }
 
-.select__field {
+.altinn-select__field {
   display: inline-flex;
   padding: 0;
 }
 
-.select--multiple .select__field,
-.select--single .select__field__button {
+.altinn-select--multiple .altinn-select__field,
+.altinn-select--single .altinn-select__field__button {
   align-items: center;
   display: inline-flex;
   flex-direction: row;
@@ -115,13 +115,13 @@
   width: 100%;
 }
 
-.select--single__field__value {
+.altinn-select--single__field__value {
   flex: 1;
   padding-left: var(--singleselect_field-padding_left);
   text-align: left;
 }
 
-.select--multiple__field__values {
+.altinn-select--multiple__field__values {
   display: inline-flex;
   flex-direction: row;
   flex-wrap: wrap;
@@ -130,11 +130,11 @@
   padding: var(--multiselect_items-padding);
 }
 
-.select--multiple .select__field__button:focus-visible {
+.altinn-select--multiple .altinn-select__field__button:focus-visible {
   outline: var(--focus_visible-outline);
 }
 
-.select__field__arrow-wrapper {
+.altinn-select__field__arrow-wrapper {
   --arrow-height: calc(
     var(--arrow-size) * var(--arrow-height_to_width_fraction)
   );
@@ -153,7 +153,7 @@
   padding: var(--arrow-vertical_padding) var(--arrow-horizontal_padding);
 }
 
-.select__field__arrow-wrapper__arrow {
+.altinn-select__field__arrow-wrapper__arrow {
   background-color: var(--arrow-color);
   clip-path: polygon(
     11.72% 9.93%,
@@ -168,7 +168,7 @@
   width: var(--arrow-size);
 }
 
-.select--multiple__field__delete-button {
+.altinn-select--multiple__field__delete-button {
   background: none;
   border-radius: var(--delete_cross_box-border_radius);
   border: none;
@@ -178,25 +178,25 @@
   width: var(--delete_cross_box-size);
 }
 
-.select--multiple__field__delete-button:disabled {
+.altinn-select--multiple__field__delete-button:disabled {
   cursor: auto;
 }
 
-.select--multiple__field__delete-button:focus-visible {
+.altinn-select--multiple__field__delete-button:focus-visible {
   outline: var(--focus_visible-outline);
 }
 
-.select--multiple__field__delete-button:hover:not(:disabled) {
+.altinn-select--multiple__field__delete-button:hover:not(:disabled) {
   background-color: var(--delete_cross_box-color-hover);
   --delete_cross-color: var(--delete_cross-color-hover);
 }
 
-.select--multiple__field__delete-button:disabled {
+.altinn-select--multiple__field__delete-button:disabled {
   --delete_cross-color: var(--delete_cross-color-disabled);
   background-color: transparent;
 }
 
-.select--multiple__field__delete-button__cross {
+.altinn-select--multiple__field__delete-button__cross {
   background-color: var(--delete_cross-color);
   clip-path: var(--delete_cross-clip_path);
   display: inline-block;
@@ -204,7 +204,7 @@
   width: var(--delete_cross-size);
 }
 
-.select__option-list {
+.altinn-select__option-list {
   background-color: var(--option_list-background_color);
   border-radius: var(--option_list-border_radius);
   border: var(--option_list-border);
@@ -222,7 +222,7 @@
   z-index: var(--option_list-z_index);
 }
 
-.select__option-list__option {
+.altinn-select__option-list__option {
   background-color: var(--option-background_color-default);
   border-color: var(--option-border_color);
   border-style: solid;
@@ -242,18 +242,18 @@
   white-space: nowrap;
 }
 
-.select__option-list__option:hover {
+.altinn-select__option-list__option:hover {
   background-color: var(--option-background_color-hover);
 }
 
-.select__option-list__option--selected {
+.altinn-select__option-list__option--selected {
   background-color: var(--option-background_color-selected);
 }
 
-.select__option-list__option--selected:hover {
+.altinn-select__option-list__option--selected:hover {
   background-color: var(--option-background_color-selected-hover);
 }
 
-.select--multiple__option-list__option--focused {
+.altinn-select--multiple__option-list__option--focused {
   outline: var(--option-outline-focus);
 }

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -173,11 +173,15 @@ describe('Select', () => {
 
     it('Gets correct state according to keyboard/mouse navigation', async () => {
       renderSingleSelect();
-      expect(getRoot().classList).not.toContain('select--using-keyboard');
+      expect(getRoot().classList).not.toContain(
+        'altinn-select--using-keyboard',
+      );
       await act(() => user.tab());
-      expect(getRoot().classList).toContain('select--using-keyboard');
+      expect(getRoot().classList).toContain('altinn-select--using-keyboard');
       await act(() => user.click(document.body));
-      expect(getRoot().classList).not.toContain('select--using-keyboard');
+      expect(getRoot().classList).not.toContain(
+        'altinn-select--using-keyboard',
+      );
     });
 
     it('Throws an error if there are duplicate values', () => {
@@ -488,11 +492,15 @@ describe('Select', () => {
 
     it('Gets correct state according to keyboard/mouse navigation', async () => {
       renderMultiSelect();
-      expect(getRoot().classList).not.toContain('select--using-keyboard');
+      expect(getRoot().classList).not.toContain(
+        'altinn-select--using-keyboard',
+      );
       await act(() => user.tab());
-      expect(getRoot().classList).toContain('select--using-keyboard');
+      expect(getRoot().classList).toContain('altinn-select--using-keyboard');
       await act(() => user.click(document.body));
-      expect(getRoot().classList).not.toContain('select--using-keyboard');
+      expect(getRoot().classList).not.toContain(
+        'altinn-select--using-keyboard',
+      );
     });
 
     it('Throws an error if there are duplicate values', () => {

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -217,11 +217,11 @@ export const Select = (props: SelectProps) => {
   return (
     <div
       className={cn(
-        classes.select,
-        classes['select--' + (multiple ? 'multiple' : 'single')],
-        expanded && classes['select--expanded'],
-        disabled && classes['select--disabled'],
-        usingKeyboard && classes['select--using-keyboard'],
+        classes['altinn-select'],
+        classes['altinn-select--' + (multiple ? 'multiple' : 'single')],
+        expanded && classes['altinn-select--expanded'],
+        disabled && classes['altinn-select--disabled'],
+        usingKeyboard && classes['altinn-select--using-keyboard'],
       )}
       data-testid='select-root'
     >
@@ -230,12 +230,14 @@ export const Select = (props: SelectProps) => {
         inputId={inputId}
         inputRenderer={({ className, inputId }) => (
           <span
-            className={cn(className, classes['select__field'])}
+            className={cn(className, classes['altinn-select__field'])}
             ref={selectFieldRef}
           >
             {multiple && (
               <>
-                <span className={classes['select--multiple__field__values']}>
+                <span
+                  className={classes['altinn-select--multiple__field__values']}
+                >
                   {selectedValues.map(findOptionFromValue).map((o) => (
                     <MultiSelectItem
                       deleteButtonLabel={
@@ -250,13 +252,17 @@ export const Select = (props: SelectProps) => {
                 </span>
                 <button
                   aria-label={props.deleteButtonLabel}
-                  className={classes['select--multiple__field__delete-button']}
+                  className={
+                    classes['altinn-select--multiple__field__delete-button']
+                  }
                   disabled={!selectedValues.length || disabled}
                   onClick={() => removeAllSelections()}
                 >
                   <span
                     className={
-                      classes['select--multiple__field__delete-button__cross']
+                      classes[
+                        'altinn-select--multiple__field__delete-button__cross'
+                      ]
                     }
                   />
                 </button>
@@ -266,7 +272,7 @@ export const Select = (props: SelectProps) => {
               aria-controls={listboxId}
               aria-expanded={expanded}
               aria-label={label}
-              className={classes['select__field__button']}
+              className={classes['altinn-select__field__button']}
               disabled={disabled}
               id={inputId}
               onBlur={() => setExpanded(false)}
@@ -281,13 +287,17 @@ export const Select = (props: SelectProps) => {
               value={multiple ? selectedValues : activeOption}
             >
               {!multiple && (
-                <span className={classes['select--single__field__value']}>
+                <span
+                  className={classes['altinn-select--single__field__value']}
+                >
                   {findOptionFromValue(activeOption).label}
                 </span>
               )}
-              <span className={classes['select__field__arrow-wrapper']}>
+              <span className={classes['altinn-select__field__arrow-wrapper']}>
                 <span
-                  className={classes['select__field__arrow-wrapper__arrow']}
+                  className={
+                    classes['altinn-select__field__arrow-wrapper__arrow']
+                  }
                 />
               </span>
             </button>
@@ -301,7 +311,7 @@ export const Select = (props: SelectProps) => {
         readOnly={false}
       />
       <ul
-        className={classes['select__option-list']}
+        className={classes['altinn-select__option-list']}
         id={listboxId}
         ref={listboxRef}
         role='listbox'
@@ -311,12 +321,14 @@ export const Select = (props: SelectProps) => {
           <li
             aria-selected={isOptionSelected(option.value)}
             className={cn(
-              classes['select__option-list__option'],
+              classes['altinn-select__option-list__option'],
               isOptionSelected(option.value) &&
-                classes['select__option-list__option--selected'],
+                classes['altinn-select__option-list__option--selected'],
               multiple &&
                 isOptionActive(option.value) &&
-                classes['select--multiple__option-list__option--focused'],
+                classes[
+                  'altinn-select--multiple__option-list__option--focused'
+                ],
             )}
             key={option.value}
             onClick={() => addOrRemoveSelectedValue(option.value)}

--- a/src/components/Tabs/Tabs.module.css
+++ b/src/components/Tabs/Tabs.module.css
@@ -1,4 +1,4 @@
-.tabs {
+.altinn-tabs {
   --divider-color: #c9c9c9;
   --divider-width: 1px;
   --tab-border_bottom_color-selected: var(--colors-blue-700);
@@ -18,7 +18,7 @@
   position: relative;
 }
 
-.tabs__tablist {
+.altinn-tabs__tablist {
   display: flex;
   gap: var(--tablist-gap);
   margin: 0 var(--tablist-margin_horizontal);
@@ -26,7 +26,7 @@
   z-index: 1;
 }
 
-.tabs__tablist__tab {
+.altinn-tabs__tablist__tab {
   background-color: transparent;
   border-bottom-color: var(--tab-border_bottom_color);
   border-bottom-style: solid;
@@ -44,21 +44,21 @@
   white-space: nowrap;
 }
 
-.tabs__tablist__tab--selected {
+.altinn-tabs__tablist__tab--selected {
   --tab-text_color: var(--tab-text_color-selected);
   --tab-border_bottom_color: var(--tab-border_bottom_color-selected);
 }
 
-.tabs__tablist__tab:hover {
+.altinn-tabs__tablist__tab:hover {
   --tab-text_color: var(--tab-text_color-hover);
 }
 
-.tabs__tablist__tab:focus-visible {
+.altinn-tabs__tablist__tab:focus-visible {
   outline: var(--component-input-color-outline-focus) auto 2px;
   outline-offset: 2px;
 }
 
-.tabs__divider {
+.altinn-tabs__divider {
   border-color: var(--divider-color);
   border-style: solid;
   border-width: var(--divider-width) 0 0 0;
@@ -69,6 +69,6 @@
   width: 100%;
 }
 
-.tabs__tabpanel {
+.altinn-tabs__tabpanel {
   margin: var(--tabpanel-margin_vertical) var(--tabpanel-margin_horizontal);
 }

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -97,17 +97,17 @@ export const Tabs = ({ activeTab, items, onChange }: TabsProps) => {
     };
 
   return (
-    <div className={classes.tabs}>
+    <div className={classes['altinn-tabs']}>
       <div
-        className={classes['tabs__tablist']}
+        className={classes['altinn-tabs__tablist']}
         ref={tablistRef}
         role='tablist'
       >
         {tabs.map((tab, i) => {
           const isSelected = tab.value === visiblePanel;
           const className = cn(
-            classes['tabs__tablist__tab'],
-            isSelected && classes['tabs__tablist__tab--selected'],
+            classes['altinn-tabs__tablist__tab'],
+            isSelected && classes['altinn-tabs__tablist__tab--selected'],
           );
           return (
             <button
@@ -126,10 +126,10 @@ export const Tabs = ({ activeTab, items, onChange }: TabsProps) => {
           );
         })}
       </div>
-      <hr className={classes['tabs__divider']} />
+      <hr className={classes['altinn-tabs__divider']} />
       {tabs.map((tab) => (
         <div
-          className={classes['tabs__tabpanel']}
+          className={classes['altinn-tabs__tabpanel']}
           aria-labelledby={tab.tabId}
           hidden={tab.value !== visiblePanel}
           id={tab.panelId}

--- a/src/components/TextArea/TextArea.module.css
+++ b/src/components/TextArea/TextArea.module.css
@@ -1,20 +1,20 @@
-.TextArea {
+.altinn-TextArea {
   font-family: inherit;
   font-size: var(--component-checkbox-font_size-sm);
 }
 
-.TextArea--resize-none {
+.altinn-TextArea--resize-none {
   resize: none;
 }
 
-.TextArea--resize-both {
+.altinn-TextArea--resize-both {
   resize: both;
 }
 
-.TextArea--resize-horizontal {
+.altinn-TextArea--resize-horizontal {
   resize: horizontal;
 }
 
-.TextArea--resize-vertical {
+.altinn-TextArea--resize-vertical {
   resize: vertical;
 }

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -41,8 +41,8 @@ export const TextArea = ({
             readOnly={Boolean(readOnly)}
             className={cn(
               className,
-              classes['TextArea'],
-              classes[`TextArea--resize-${resize}`],
+              classes['altinn-TextArea'],
+              classes[`altinn-TextArea--resize-${resize}`],
             )}
           />
         );

--- a/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.module.css
+++ b/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.module.css
@@ -1,4 +1,4 @@
-.template {
+.altinn-template {
   --cursor: pointer;
   --description-color: var(--component-field_description-color-text-default);
   --label-color: var(--component-checkbox-color-text-default);
@@ -14,41 +14,41 @@
   opacity: var(--opacity);
 }
 
-.template--xsmall {
+.altinn-template--xsmall {
   --description-margin_top: var(--component-field_description-space-top-xsmall);
   --font_size: var(--component-checkbox-font_size-xs);
   --gap: var(--component-checkbox-space-gap-xsmall);
 }
 
-.template--small {
+.altinn-template--small {
   --description-margin_top: var(--component-field_description-space-top-small);
   --font_size: var(--component-checkbox-font_size-sm);
   --gap: var(--component-checkbox-space-gap-small);
 }
 
-.template:not(.template--disabled):hover {
+.altinn-template:not(.altinn-template--disabled):hover {
   --label-color: var(--component-checkbox-color-text-hover);
 }
 
-.template--disabled {
+.altinn-template--disabled {
   --cursor: auto;
   --opacity: var(--interactive_components-colors-disabled-opacity);
 }
 
-.template__input-wrapper {
+.altinn-template__input-wrapper {
   display: inline-block;
   height: var(--input_box-size);
   position: relative;
 }
 
-.template__input-wrapper__input {
+.altinn-template__input-wrapper__input {
   height: 0;
   opacity: 0;
   position: absolute;
   width: 0;
 }
 
-.template__input-wrapper__visible-box {
+.altinn-template__input-wrapper__visible-box {
   display: inline-block;
   flex: 0 0 var(--input_box-size);
   height: var(--input_box-size);
@@ -56,7 +56,7 @@
   width: var(--input_box-size);
 }
 
-.template__label-and-description {
+.altinn-template__label-and-description {
   display: inline-flex;
   flex-direction: column;
   gap: var(--description-margin_top);
@@ -70,22 +70,22 @@
   );
 }
 
-.template__label-and-description__label {
+.altinn-template__label-and-description__label {
   color: var(--label-color);
 }
 
-.template__label-and-description__description {
+.altinn-template__label-and-description__description {
   color: var(--description-color);
 }
 
 @supports not selector(:has(:focus-visible)) {
-  .template:not(.template--disabled):focus-within {
+  .altinn-template:not(.altinn-template--disabled):focus-within {
     outline: 2px solid var(--interactive_components-colors-focus_outline);
     outline-offset: 2px;
   }
 }
 
-.template:not(.template--disabled):has(:focus-visible) {
+.altinn-template:not(.altinn-template--disabled):has(:focus-visible) {
   outline: 2px solid var(--interactive_components-colors-focus_outline);
   outline-offset: 2px;
 }

--- a/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.test.tsx
+++ b/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.test.tsx
@@ -57,28 +57,28 @@ describe('CheckboxRadioTemplate', () => {
   it('Renders with "xsmall" class if size is set to "Xsmall"', () => {
     const size = CheckboxRadioTemplateSize.Xsmall;
     const wrapper = renderAndGetWrapper({ size });
-    expect(wrapper).toHaveClass('template--xsmall');
+    expect(wrapper).toHaveClass('altinn-template--xsmall');
   });
 
   it('Renders with "small" class if size is set to "Small"', () => {
     const size = CheckboxRadioTemplateSize.Small;
     const wrapper = renderAndGetWrapper({ size });
-    expect(wrapper).toHaveClass('template--small');
+    expect(wrapper).toHaveClass('altinn-template--small');
   });
 
   it('Does not render with "disabled" class by default', () => {
     const wrapper = renderAndGetWrapper();
-    expect(wrapper).not.toHaveClass('template--disabled');
+    expect(wrapper).not.toHaveClass('altinn-template--disabled');
   });
 
   it('Renders with "disabled" class if the "disabled" property is true', () => {
     const wrapper = renderAndGetWrapper({ disabled: true });
-    expect(wrapper).toHaveClass('template--disabled');
+    expect(wrapper).toHaveClass('altinn-template--disabled');
   });
 
   it('Does not render with "disabled" class if the "disabled" property is false', () => {
     const wrapper = renderAndGetWrapper({ disabled: false });
-    expect(wrapper).not.toHaveClass('template--disabled');
+    expect(wrapper).not.toHaveClass('altinn-template--disabled');
   });
 });
 
@@ -95,7 +95,7 @@ const renderAndGetWrapper = (
   props: Partial<CheckboxRadioTemplateProps> = {},
 ): Element => {
   const { container } = render(props);
-  const wrapper = container.querySelector('.template');
+  const wrapper = container.querySelector('.altinn-template');
   assert(wrapper !== null);
   return wrapper;
 };

--- a/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx
+++ b/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx
@@ -59,15 +59,15 @@ export const CheckboxRadioTemplate = ({
   return (
     <label
       className={cn(
-        classes.template,
-        classes[`template--${size}`],
-        disabled && classes['template--disabled'],
+        classes['altinn-template'],
+        classes[`altinn-template--${size}`],
+        disabled && classes['altinn-template--disabled'],
         className,
       )}
       htmlFor={inputId}
     >
       {!hideInput && (
-        <span className={classes['template__input-wrapper']}>
+        <span className={classes['altinn-template__input-wrapper']}>
           <input
             aria-describedby={descriptionId}
             aria-label={
@@ -75,7 +75,7 @@ export const CheckboxRadioTemplate = ({
             }
             aria-labelledby={showLabel ? labelId : undefined}
             checked={checked ?? false}
-            className={classes['template__input-wrapper__input']}
+            className={classes['altinn-template__input-wrapper__input']}
             disabled={disabled}
             id={finalInputId}
             name={name}
@@ -84,16 +84,20 @@ export const CheckboxRadioTemplate = ({
             type={type}
             value={value}
           />
-          <span className={classes['template__input-wrapper__visible-box']}>
+          <span
+            className={classes['altinn-template__input-wrapper__visible-box']}
+          >
             {children}
           </span>
         </span>
       )}
       {(showLabel || description) && (
-        <span className={classes['template__label-and-description']}>
+        <span className={classes['altinn-template__label-and-description']}>
           {showLabel && (
             <span
-              className={classes['template__label-and-description__label']}
+              className={
+                classes['altinn-template__label-and-description__label']
+              }
               id={labelId}
             >
               {label}
@@ -102,7 +106,7 @@ export const CheckboxRadioTemplate = ({
           {description && (
             <span
               className={
-                classes['template__label-and-description__description']
+                classes['altinn-template__label-and-description__description']
               }
               id={descriptionId}
             >


### PR DESCRIPTION
## Description
When using components that has been copied to Digdir's design system, but not yet removed from this one, consumers might experience issues related to colliding class names. After discussing with @framitdavid, we decided to add a prefix to the class names of these components to avoid this problem.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] All tests run green
