### PR TITLE
Add deprecation flag to Accordion

### DIFF
--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -35,6 +35,7 @@ export default {
       page: () => (
         <StoryPage
           description={`TODO: Add a description (supports markdown)`}
+          deprecationWarning={`Use Accordion from @digdir/design-system-react instead.`}
         />
       ),
     },

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -11,6 +11,9 @@ export interface AccordionProps {
   iconVariant?: AccordionIconVariant;
 }
 
+/*
+ * @deprecated Use Accordion from @digdir/design-system-react instead.
+ */
 export const Accordion = ({
   children,
   open,


### PR DESCRIPTION
## Description
Added deprecation flag to `Accordion`, as it has been moved to Digdir's design system.

## Related Issue(s)
- #235

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] All tests run green
