### PR TITLE
Fix Jsdoc syntax

### DIFF
--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -11,7 +11,7 @@ export interface AccordionProps {
   iconVariant?: AccordionIconVariant;
 }
 
-/*
+/**
  * @deprecated Use Accordion from @digdir/design-system-react instead.
  */
 export const Accordion = ({

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -39,7 +39,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   iconPlacement?: 'right' | 'left';
 }
 
-/*
+/**
  * @deprecated Use Button from @digdir/design-system-react instead.
  */
 const Button = (

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -24,7 +24,7 @@ export interface CheckboxProps {
   readOnly?: boolean;
 }
 
-/*
+/**
  * @deprecated Use Checkbox from @digdir/design-system-react instead.
  */
 export const Checkbox = ({

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -53,7 +53,7 @@ const reducer = (state: CheckedNames, action: ReducerAction) => {
 const checkedItems = (items: CheckboxItem[]) =>
   items.filter(({ checked }) => checked).map(({ name }) => name);
 
-/*
+/**
  * @deprecated Use CheckboxGroup from @digdir/design-system-react instead.
  */
 export const CheckboxGroup = ({

--- a/src/components/ErrorMessage/ErrorMessage.tsx
+++ b/src/components/ErrorMessage/ErrorMessage.tsx
@@ -8,7 +8,7 @@ export interface ErrorMessageProps {
   ariaLabel?: string;
 }
 
-/*
+/**
  * @deprecated Use ErrorMessage from @digdir/design-system-react instead.
  */
 export const ErrorMessage = ({

--- a/src/components/FieldSet/FieldSet.tsx
+++ b/src/components/FieldSet/FieldSet.tsx
@@ -21,7 +21,7 @@ export enum FieldSetSize {
   Small = 'small',
 }
 
-/*
+/**
  * @deprecated Use FieldSet from @digdir/design-system-react instead.
  */
 export const FieldSet = ({

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -30,7 +30,7 @@ export interface RadioButtonProps {
   value: string;
 }
 
-/*
+/**
  * @deprecated Use RadioButton from @digdir/design-system-react instead.
  */
 export const RadioButton = ({

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -39,7 +39,7 @@ export interface RadioGroupProps {
   variant?: RadioGroupVariant;
 }
 
-/*
+/**
  * @deprecated Use RadioGroup from @digdir/design-system-react instead.
  */
 export const RadioGroup = ({

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -51,7 +51,7 @@ const eventListenerKeys = {
   Enter: 'Enter',
 };
 
-/*
+/**
  * @deprecated Use Select from @digdir/design-system-react instead.
  */
 export const Select = (props: SelectProps) => {

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -23,7 +23,7 @@ export interface TabsProps {
 
 const validId = (str: string) => str.replace(/\s/, '_');
 
-/*
+/**
  * @deprecated Use Tabs from @digdir/design-system-react instead.
  */
 export const Tabs = ({ activeTab, items, onChange }: TabsProps) => {

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -14,7 +14,7 @@ export interface TextAreaProps
   resize?: 'none' | 'both' | 'horizontal' | 'vertical';
 }
 
-/*
+/**
  * @deprecated Use TextArea from @digdir/design-system-react instead.
  */
 export const TextArea = ({

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -80,7 +80,7 @@ const numericKeyDown = (
   }
 };
 
-/*
+/**
  * @deprecated Use TextField from @digdir/design-system-react instead.
  */
 export const TextField = ({

--- a/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx
+++ b/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx
@@ -1,4 +1,4 @@
-/*
+/**
  * This is an internal component used for the Checkbox and RadioButton components,
  * as they have several similarities.
  */


### PR DESCRIPTION
## Description
Fix Jsdoc syntax to make code tools recognize the `@deprecated` flag.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] All tests run green
