### PR TITLE
fix sort arrows list component

### DIFF
--- a/src/components/Table/TableCell.tsx
+++ b/src/components/Table/TableCell.tsx
@@ -95,10 +95,10 @@ export function TableCell({
                 data-testid='sort-icon'
                 className={
                   sortDirection == SortDirection.NotActive
-                    ? cn(classes['icon'])
+                    ? classes.icon
                     : sortDirection == SortDirection.Ascending
-                    ? cn(classes['icon-asc'])
-                    : cn(classes['icon-desc'])
+                    ? classes['icon-asc']
+                    : classes['icon-desc']
                 }
               ></SortIcon>
             )}

--- a/src/components/Table/TableCell.tsx
+++ b/src/components/Table/TableCell.tsx
@@ -93,12 +93,13 @@ export function TableCell({
               <SortIcon
                 aria-label='Sortering'
                 data-testid='sort-icon'
-                className={cn(classes['icon'], {
-                  [classes['icon-asc']]:
-                    sortDirection === SortDirection.Ascending,
-                  [classes['icon-desc']]:
-                    sortDirection === SortDirection.Descending,
-                })}
+                className={
+                  sortDirection == SortDirection.NotActive
+                    ? cn(classes['icon'])
+                    : sortDirection == SortDirection.Ascending
+                    ? cn(classes['icon-asc'])
+                    : cn(classes['icon-desc'])
+                }
               ></SortIcon>
             )}
           </div>


### PR DESCRIPTION
## Description
Sort arrows did not turn black when active in altinn-app. Fix to see what sortable column is active when there is more than one sortable column.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
