### PR TITLE
Mark moved components as deprecated

### DIFF
--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -29,6 +29,7 @@ export default {
       page: () => (
         <StoryPage
           description={`TODO: Add a description (supports markdown)`}
+          deprecationWarning={`Use List from @digdir/design-system-react instead.`}
         />
       ),
     },

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -9,6 +9,9 @@ export interface ListProps {
   borderStyle?: BorderStyle;
 }
 
+/**
+ * @deprecated Use List from @digdir/design-system-react instead.
+ */
 export const List = ({
   children,
   borderStyle = BorderStyle.Solid,

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -42,6 +42,7 @@ export default {
       page: () => (
         <StoryPage
           description={`TODO: Add a description (supports markdown)`}
+          deprecationWarning={`Use Table from @digdir/design-system-react instead.`}
         />
       ),
     },

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -14,6 +14,9 @@ export interface TableProps<T>
   selectedValue?: T;
 }
 
+/**
+ * @deprecated Use Table from @digdir/design-system-react instead.
+ */
 export function Table<T>({
   children,
   selectRows = false,

--- a/src/components/ToggleButtonGroup/ToggleButtonGroup.stories.tsx
+++ b/src/components/ToggleButtonGroup/ToggleButtonGroup.stories.tsx
@@ -29,6 +29,7 @@ export default {
       page: () => (
         <StoryPage
           description={`TODO: Add a description (supports markdown)`}
+          deprecationWarning={`Use ToggleButtonGroup from @digdir/design-system-react instead.`}
         />
       ),
     },

--- a/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -11,6 +11,9 @@ export interface ToggleButtonGroupProps {
   selectedValue: string;
 }
 
+/**
+ * @deprecated Use ToggleButtonGroup from @digdir/design-system-react instead.
+ */
 export const ToggleButtonGroup = ({
   children,
   onChange,


### PR DESCRIPTION
## Description
Mark components that have been moved to DIgdir's design system as deprecated.

## Related Issue(s)
- #235

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] All tests run green
