### PR TITLE
Remove storybook-addon-designs plugin

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -16,7 +16,6 @@ module.exports = {
     '@storybook/addon-a11y',
     'storybook-addon-turbo-build',
     'storybook-dark-mode',
-    'storybook-addon-designs',
   ],
   core: {
     builder: 'webpack5',

--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
     "rollup-plugin-peer-deps-external": "2.2.4",
     "rollup-plugin-postcss": "4.0.2",
     "semver": "7.5.1",
-    "storybook-addon-designs": "6.3.1",
     "storybook-addon-turbo-build": "1.1.0",
     "storybook-dark-mode": "2.1.1",
     "terser": "5.17.7",

--- a/scripts/templates/Component/_COMPONENT_.stories.tsx
+++ b/scripts/templates/Component/_COMPONENT_.stories.tsx
@@ -1,27 +1,14 @@
 import React from 'react';
 import type { ComponentStory, ComponentMeta } from '@storybook/react';
-import { config } from 'storybook-addon-designs';
 
 import { StoryPage } from '@sb/StoryPage';
 
 import { _COMPONENT_ } from './_COMPONENT_';
 
-const figmaLink = ''; // TODO: Add figma link
-
 export default {
   title: `Components/_COMPONENT_`,
   component: _COMPONENT_,
   parameters: {
-    design: config([
-      {
-        type: 'figma',
-        url: figmaLink,
-      },
-      {
-        type: 'link',
-        url: figmaLink,
-      },
-    ]),
     docs: {
       page: () => (
         <StoryPage

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import type { ComponentStory, ComponentMeta } from '@storybook/react';
-import { config } from 'storybook-addon-designs';
 import { useArgs } from '@storybook/client-api';
 import cn from 'classnames';
 import {
@@ -18,23 +17,11 @@ import { AccordionContent } from './AccordionContent';
 import classes from './Accordion.stories.module.css';
 import { AccordionIconVariant } from './Context';
 
-const figmaLink = ''; // TODO: Add figma link
-
 export default {
   title: `Components/Accordion`,
   component: Accordion,
   subcomponents: { AccordionHeader, AccordionContent },
   parameters: {
-    design: config([
-      {
-        type: 'figma',
-        url: figmaLink,
-      },
-      {
-        type: 'link',
-        url: figmaLink,
-      },
-    ]),
     docs: {
       page: () => (
         <StoryPage

--- a/src/components/CircularProgress/CircularProgress.stories.tsx
+++ b/src/components/CircularProgress/CircularProgress.stories.tsx
@@ -1,28 +1,14 @@
 import React from 'react';
 import type { ComponentStory, ComponentMeta } from '@storybook/react';
-import { config } from 'storybook-addon-designs';
 
 import { StoryPage } from '@sb/StoryPage';
 
 import { CircularProgress } from './CircularProgress';
 
-const figmaLink =
-  'https://www.figma.com/file/wnBveAG2ikUspFsQwM3GNE/Altinn-Studio-Apps?node-id=17152%3A33460';
-
 export default {
   title: `Components/CircularProgress`,
   component: CircularProgress,
   parameters: {
-    design: config([
-      {
-        type: 'figma',
-        url: figmaLink,
-      },
-      {
-        type: 'link',
-        url: figmaLink,
-      },
-    ]),
     docs: {
       page: () => (
         <StoryPage

--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import type { ComponentStory, ComponentMeta } from '@storybook/react';
-import { config } from 'storybook-addon-designs';
 
 import { StoryPage } from '@sb/StoryPage';
 
@@ -9,22 +8,10 @@ import { ListItem } from './ListItem';
 import { BorderStyle } from './Context';
 import classes from './List.stories.modules.css';
 
-const figmaLink = ''; // TODO: Add figma link
-
 export default {
   title: `Components/List`,
   component: List,
   parameters: {
-    design: config([
-      {
-        type: 'figma',
-        url: figmaLink,
-      },
-      {
-        type: 'link',
-        url: figmaLink,
-      },
-    ]),
     docs: {
       page: () => (
         <StoryPage

--- a/src/components/Map/Map.stories.tsx
+++ b/src/components/Map/Map.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import type { ComponentStory, ComponentMeta } from '@storybook/react';
-import { config } from 'storybook-addon-designs';
 import { useArgs } from '@storybook/client-api';
 import Marker from 'leaflet/dist/images/marker-icon.png';
 import RetinaMarker from 'leaflet/dist/images/marker-icon-2x.png';
@@ -11,23 +10,11 @@ import { StoryPage } from '@sb/StoryPage';
 import type { Location } from './Map';
 import { Map } from './Map';
 
-const figmaLink = '';
-
 export default {
   title: `Components/Map`,
   component: Map,
   parameters: {
     layout: 'fullscreen',
-    design: config([
-      {
-        type: 'figma',
-        url: figmaLink,
-      },
-      {
-        type: 'link',
-        url: figmaLink,
-      },
-    ]),
     docs: {
       page: () => <StoryPage description={`Map component`} />,
     },

--- a/src/components/Page/Page.stories.tsx
+++ b/src/components/Page/Page.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import type { ComponentStory, ComponentMeta } from '@storybook/react';
-import { config } from 'storybook-addon-designs';
 
 import { StoryPage } from '@sb/StoryPage';
 import { ReactComponent as DataIcon } from '@/assets/Data.svg';
@@ -10,22 +9,10 @@ import { PageContent } from './PageContent';
 import { PageHeader } from './PageHeader';
 import { Page } from './Page';
 
-const figmaLink = ''; // TODO: Add figma link
-
 export default {
   title: `Components/Page`,
   component: Page,
   parameters: {
-    design: config([
-      {
-        type: 'figma',
-        url: figmaLink,
-      },
-      {
-        type: 'link',
-        url: figmaLink,
-      },
-    ]),
     docs: {
       page: () => (
         <StoryPage

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -1,13 +1,10 @@
 import React, { useState } from 'react';
 import type { ComponentStory, ComponentMeta } from '@storybook/react';
-import { config } from 'storybook-addon-designs';
 
 import { StoryPage } from '@sb/StoryPage';
 
 import type { DescriptionText } from './Pagination';
 import { Pagination } from './Pagination';
-
-const figmaLink = ''; // TODO: Add figma link
 
 /**
  * Do not use these directly. They are exported here for re-use in Storyboard, but you should supply your own
@@ -26,16 +23,6 @@ export default {
   title: `Components/Pagination`,
   component: Pagination,
   parameters: {
-    design: config([
-      {
-        type: 'figma',
-        url: figmaLink,
-      },
-      {
-        type: 'link',
-        url: figmaLink,
-      },
-    ]),
     docs: {
       page: () => (
         <StoryPage

--- a/src/components/Panel/Panel.stories.tsx
+++ b/src/components/Panel/Panel.stories.tsx
@@ -1,27 +1,14 @@
 import React from 'react';
 import type { ComponentStory, ComponentMeta } from '@storybook/react';
-import { config } from 'storybook-addon-designs';
 
 import { StoryPage } from '@sb/StoryPage';
 
 import { Panel, PanelVariant } from './Panel';
 
-const figmaLink =
-  'https://www.figma.com/file/wnBveAG2ikUspFsQwM3GNE/Altinn-Studio-Apps?node-id=15055%3A17514';
 export default {
   title: `Components/Panel`,
   component: Panel,
   parameters: {
-    design: config([
-      {
-        type: 'figma',
-        url: figmaLink,
-      },
-      {
-        type: 'link',
-        url: figmaLink,
-      },
-    ]),
     docs: {
       page: () => (
         <StoryPage

--- a/src/components/Panel/PopoverPanel.stories.tsx
+++ b/src/components/Panel/PopoverPanel.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import type { ComponentStory, ComponentMeta } from '@storybook/react';
-import { config } from 'storybook-addon-designs';
 import { useState } from '@storybook/addons';
 import {
   Button,
@@ -14,22 +13,10 @@ import { StoryPage } from '@sb/StoryPage';
 import { PanelVariant } from './Panel';
 import { PopoverPanel } from './PopoverPanel';
 
-const figmaLink = ''; // TODO: Add figma link
-
 export default {
   title: `Components/Panel/PopoverPanel`,
   component: PopoverPanel,
   parameters: {
-    design: config([
-      {
-        type: 'figma',
-        url: figmaLink,
-      },
-      {
-        type: 'link',
-        url: figmaLink,
-      },
-    ]),
     docs: {
       page: () => (
         <StoryPage

--- a/src/components/SearchField/SearchField.stories.tsx
+++ b/src/components/SearchField/SearchField.stories.tsx
@@ -1,29 +1,15 @@
 import React from 'react';
 import type { ComponentStory, ComponentMeta } from '@storybook/react';
-import { config } from 'storybook-addon-designs';
 import { useArgs } from '@storybook/client-api';
 
 import { StoryPage } from '@sb/StoryPage';
 
 import { SearchField } from './SearchField';
 
-const figmaLink =
-  'https://www.figma.com/file/wnBveAG2ikUspFsQwM3GNE/Altinn-Studio-Apps?node-id=2090%3A6723';
-
 export default {
   title: `Components/SearchField`,
   component: SearchField,
   parameters: {
-    design: config([
-      {
-        type: 'figma',
-        url: figmaLink,
-      },
-      {
-        type: 'link',
-        url: figmaLink,
-      },
-    ]),
     docs: {
       page: () => (
         <StoryPage

--- a/src/components/SvgIcon/Stories/SvgIcon.stories.tsx
+++ b/src/components/SvgIcon/Stories/SvgIcon.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import type { ComponentStory, ComponentMeta } from '@storybook/react';
-import { config } from 'storybook-addon-designs';
 import { Success as SuccessIconNAV } from '@navikt/ds-icons';
 
 import { StoryPage } from '@sb/StoryPage';
@@ -9,22 +8,10 @@ import { SvgIcon } from '..';
 
 import { ReactComponent as SuccessIcon } from './success.svg';
 
-const figmaLink = ''; // TODO: Add figma link
-
 export default {
   title: `Components/SvgIcon`,
   component: SvgIcon,
   parameters: {
-    design: config([
-      {
-        type: 'figma',
-        url: figmaLink,
-      },
-      {
-        type: 'link',
-        url: figmaLink,
-      },
-    ]),
     docs: {
       page: () => (
         <StoryPage

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import type { ComponentStory, ComponentMeta } from '@storybook/react';
-import { config } from 'storybook-addon-designs';
 import cn from 'classnames';
 import { RadioButton } from '@digdir/design-system-react';
 
@@ -22,22 +21,10 @@ import { SortDirection } from './Toolbox';
 import classes from './Table.stories.module.css';
 import { TableFooter } from './TableFooter';
 
-const figmaLink = ''; // TODO: Add figma link
-
 export default {
   title: `Components/Table`,
   component: Table,
   parameters: {
-    design: config([
-      {
-        type: 'figma',
-        url: figmaLink,
-      },
-      {
-        type: 'link',
-        url: figmaLink,
-      },
-    ]),
     docs: {
       page: () => (
         <StoryPage

--- a/yarn.lock
+++ b/yarn.lock
@@ -88,7 +88,6 @@ __metadata:
     rollup-plugin-peer-deps-external: 2.2.4
     rollup-plugin-postcss: 4.0.2
     semver: 7.5.1
-    storybook-addon-designs: 6.3.1
     storybook-addon-turbo-build: 1.1.0
     storybook-dark-mode: 2.1.1
     terser: 5.17.7
@@ -3304,27 +3303,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@figspec/components@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "@figspec/components@npm:1.0.1"
-  dependencies:
-    lit: ^2.1.3
-  checksum: db33333ad2c3925cc8264e24b4a7b7d0e3a477eaaebbff9033f78c3e2f3273e6c7dbdfb453ee16af6d1ab21d49c2c704882aabcb1a693d2cf627b1fa2494849b
-  languageName: node
-  linkType: hard
-
-"@figspec/react@npm:^1.0.0":
-  version: 1.0.2
-  resolution: "@figspec/react@npm:1.0.2"
-  dependencies:
-    "@figspec/components": ^1.0.0
-    "@lit-labs/react": ^1.0.2
-  peerDependencies:
-    react: ^16.14.0 || ^17.0.0 || ^18.0.0
-  checksum: b40ec22c1d465d85f28bbcd916ad1c66603555270401f8162b2c385252b40059c5bb15cc9081962521790decf910072240477a83c57ecb2d4580cf7e678e551e
-  languageName: node
-  linkType: hard
-
 "@floating-ui/core@npm:^1.2.6":
   version: 1.2.6
   resolution: "@floating-ui/core@npm:1.2.6"
@@ -3809,20 +3787,6 @@ __metadata:
     "@jridgewell/resolve-uri": 3.1.0
     "@jridgewell/sourcemap-codec": 1.4.14
   checksum: 0572669f855260808c16fe8f78f5f1b4356463b11d3f2c7c0b5580c8ba1cbf4ae53efe9f627595830856e57dbac2325ac17eb0c3dd0ec42102e6f227cc289c02
-  languageName: node
-  linkType: hard
-
-"@lit-labs/react@npm:^1.0.2":
-  version: 1.0.8
-  resolution: "@lit-labs/react@npm:1.0.8"
-  checksum: 249f6d385c1f2b3e69941fc267f4928321334ea8e0e6ffda1e2a6ab3bad07b780c7cc2b19e7c9f36ae35376cba5ffa6162ccd92e9bea67411b6f59864924e9c0
-  languageName: node
-  linkType: hard
-
-"@lit/reactive-element@npm:^1.3.0, @lit/reactive-element@npm:^1.4.0":
-  version: 1.4.1
-  resolution: "@lit/reactive-element@npm:1.4.1"
-  checksum: 27cf706217e9148e140b467185fb813165b2e2aad732fc578c26e566115fa6de73b85bdcd34137d839e004b76d7ae508940abcbd661059b69bc07d7fb6dcb754
   languageName: node
   linkType: hard
 
@@ -6911,13 +6875,6 @@ __metadata:
   version: 1.0.0
   resolution: "@types/treeify@npm:1.0.0"
   checksum: 1b2397030d13beee7f82b878ca80feeddb0d550a6b00d8be30082a370c0ac5985ecf7b9378cf93ea278ff00c3e900b416ae8d9379f2c7e8caecdece1dfc77380
-  languageName: node
-  linkType: hard
-
-"@types/trusted-types@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "@types/trusted-types@npm:2.0.2"
-  checksum: 3371eef5f1c50e1c3c07a127c1207b262ba65b83dd167a1c460fc1b135a3fb0c97b9f508efebd383f239cc5dd5b7169093686a692a501fde9c3f7208657d9b0d
   languageName: node
   linkType: hard
 
@@ -15832,36 +15789,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lit-element@npm:^3.2.0":
-  version: 3.2.2
-  resolution: "lit-element@npm:3.2.2"
-  dependencies:
-    "@lit/reactive-element": ^1.3.0
-    lit-html: ^2.2.0
-  checksum: e1df57c02ad5ae4c42b49a5066b3b623bccf7fa6610bbc3f65bc22cbbe1546ecd6a7f717b1f01863929262f416c4b8b7a39ff166114215f93cc22f4e5b3825c3
-  languageName: node
-  linkType: hard
-
-"lit-html@npm:^2.2.0, lit-html@npm:^2.3.0":
-  version: 2.3.1
-  resolution: "lit-html@npm:2.3.1"
-  dependencies:
-    "@types/trusted-types": ^2.0.2
-  checksum: 6177f0854001b7e464a994adb6339a5ede4977c189587e49186b8bb10e49feaa57fe08ad14d13c06c2bce2a80671e1de3f08d8f2bdb25b2f265b21e2dd091c5b
-  languageName: node
-  linkType: hard
-
-"lit@npm:^2.1.3":
-  version: 2.3.1
-  resolution: "lit@npm:2.3.1"
-  dependencies:
-    "@lit/reactive-element": ^1.4.0
-    lit-element: ^3.2.0
-    lit-html: ^2.3.0
-  checksum: 0af92e606ec35fc1931ef4a6fa6aaa9c186e6329cefcba8feb14507187653ae94e0d0cf554530d969c411ae7b9256b4e5c5d0bf373caf02f2147047aeeac946a
-  languageName: node
-  linkType: hard
-
 "load-json-file@npm:^1.0.0":
   version: 1.1.0
   resolution: "load-json-file@npm:1.1.0"
@@ -20554,15 +20481,6 @@ __metadata:
   version: 2.14.2
   resolution: "store2@npm:2.14.2"
   checksum: 6f270fc5bab99b63f45fcc7bd8b99c2714b4adf880f557ed7ffb5ed3987131251165bccde425a00928aaf044870aee79ddeef548576d093c68703ed2edec45d7
-  languageName: node
-  linkType: hard
-
-"storybook-addon-designs@npm:6.3.1":
-  version: 6.3.1
-  resolution: "storybook-addon-designs@npm:6.3.1"
-  dependencies:
-    "@figspec/react": ^1.0.0
-  checksum: 63d91358540a59801028b4fe2fe61a2cad52ac2354efde0959f081379045230af4ea6dea6a8abddae2a7eb14699fd04024dec44b6fd396065e0e585d31980635
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
The `storybook-addon-designs` plugin doesn't support Storybook 7, so it has to be removed before upgrading. We probably don't need it anyways.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] All tests run green
