### PR TITLE
Update map-layers to use the new cache service

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -20,7 +20,7 @@ const DefaultCenterLocation: Location = {
 };
 const DefaultZoom = 4;
 
-// Default zoom level that should be used when flying to new markerLocation
+// Default zoom level that should be used when flying to the new markerLocation
 const DefaultFlyToZoomLevel = 16;
 
 // Default map layer from Kartverket

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -23,12 +23,8 @@ const DefaultZoom = 4;
 // Default zoom level that should be used when flying to new markerLocation
 const DefaultFlyToZoomLevel = 16;
 
-// Default map layers from Kartverket
+// Default map layer from Kartverket
 const DefaultMapLayers: MapLayer[] = [
-  {
-    url: 'https://opencache.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=europa_forenklet&zoom={z}&x={x}&y={y}',
-    attribution: 'Data © <a href="https://www.kartverket.no/">Kartverket</a>',
-  },
   {
     url: 'https://cache.kartverket.no/v1/wmts/1.0.0/topo/default/webmercator/{z}/{y}/{x}.png',
     attribution: 'Data © <a href="https://www.kartverket.no/">Kartverket</a>',

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -20,7 +20,7 @@ const DefaultCenterLocation: Location = {
 };
 const DefaultZoom = 4;
 
-// Default zoom level that should be used when when flying to new markerLocation
+// Default zoom level that should be used when flying to new markerLocation
 const DefaultFlyToZoomLevel = 16;
 
 // Default map layers from Kartverket
@@ -30,7 +30,7 @@ const DefaultMapLayers: MapLayer[] = [
     attribution: 'Data © <a href="https://www.kartverket.no/">Kartverket</a>',
   },
   {
-    url: 'https://opencache.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=norgeskart_bakgrunn2&zoom={z}&x={x}&y={y}',
+    url: 'https://cache.kartverket.no/v1/wmts/1.0.0/topo/default/webmercator/{z}/{y}/{x}.png',
     attribution: 'Data © <a href="https://www.kartverket.no/">Kartverket</a>',
   },
 ];


### PR DESCRIPTION
Bug FIxes:

- Moved the old cache server for Map.tsx to the new one to prevent map component to fetch from outdated and soon-to-be-deleted cache service.